### PR TITLE
Release 7.1.0: sync from GitLab release/7.1.0

### DIFF
--- a/nvidia_tao_core/config/clip/default_config.py
+++ b/nvidia_tao_core/config/clip/default_config.py
@@ -168,6 +168,24 @@ class CLIPDataPathConfig:
                     "Caption filename = image_basename + caption_file_suffix (e.g., 'image.png' -> 'image.txt').",
         display_name="Caption File Suffix",
     )
+    train_pairs_file: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description=(
+            "Optional train_pairs.json metadata file used for balanced PAS "
+            "query-type sampling."
+        ),
+        display_name="Train Pairs File",
+    )
+    attribute_pairs_file: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description=(
+            "Optional split-aligned pairs metadata file used for "
+            "metadata-aware validation."
+        ),
+        display_name="Attribute Pairs File",
+    )
 
 
 @dataclass
@@ -232,6 +250,31 @@ class CLIPTrainDataConfig(CLIPDataLoaderConfig):
         description="Dataset type: 'custom' for filesystem-based or 'wds' for WebDataset.",
         display_name="Dataset Type",
     )
+    balance_query_types: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Balance CLIP training batches across query types using train_pairs_file metadata.",
+        display_name="Balance Query Types",
+    )
+    unique_caption_per_batch: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        description=(
+            "When balance_query_types is enabled, enforce at most one row per caption "
+            "string in each batch. Disable for very large PAS-Aug datasets to avoid "
+            "expensive unique-caption batch construction."
+        ),
+        display_name="Unique Caption per Batch",
+    )
+    include_attribute_metadata: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Include image/text attribute tensors in custom training batches. "
+            "Required when siglip_loss_mask_mode is enabled."
+        ),
+        display_name="Include Attribute Metadata",
+    )
     wds: Optional[CLIPWDSConfig] = DATACLASS_FIELD(
         CLIPWDSConfig(),
         description="WebDataset configuration (used when type='wds').",
@@ -249,7 +292,28 @@ class CLIPTrainDataConfig(CLIPDataLoaderConfig):
 class CLIPValDataConfig(CLIPDataLoaderConfig):
     """Validation data configuration for retrieval evaluation."""
 
-    pass
+    metadata_match_eval: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Use attribute metadata to define text-to-image validation "
+            "positives. Multiple datasets must use identical attribute and "
+            "accessory vocabularies. When False, validation keeps paired "
+            "diagonal ground truth."
+        ),
+        display_name="Metadata Match Evaluation",
+    )
+    metadata_match_mode: str = STR_FIELD(
+        value="scalar_attributes",
+        default_value="scalar_attributes",
+        valid_options="scalar_attributes,scalar_plus_accessories",
+        description=(
+            "Metadata compatibility used for text-to-image validation. "
+            "'scalar_plus_accessories' also requires every query accessory "
+            "to be present in the image."
+        ),
+        display_name="Metadata Match Mode",
+    )
 
 
 @dataclass
@@ -367,6 +431,50 @@ class CLIPTrainConfig(TrainConfig):
         description="Contrastive loss function: 'siglip' (sigmoid) or 'clip' (softmax).",
         display_name="Loss Type",
     )
+    siglip_loss_dist_impl: str = STR_FIELD(
+        value="gather",
+        default_value="gather",
+        valid_options="bidir,shift,reduce,gather,local",
+        description=(
+            "Distributed implementation for SigLIP loss negative exchange. "
+            "Metadata masking supports local and gather. "
+            "Only used when loss_type is 'siglip'."
+        ),
+        display_name="SigLIP Loss Distributed Implementation",
+    )
+    siglip_loss_mask_mode: str = STR_FIELD(
+        value="none",
+        default_value="none",
+        valid_options="none,attribute_match_ignore,attribute_plus_accessory_match_ignore",
+        description=(
+            "Optional metadata-based masking mode for SigLIP loss. "
+            "'none' keeps existing behavior; 'attribute_match_ignore' ignores "
+            "off-diagonal negatives whose attributes match the text query; "
+            "'attribute_plus_accessory_match_ignore' additionally requires "
+            "all query accessories to be present in the image. "
+            "Metadata masking supports local and gather. Non-'none' modes require "
+            "dataset.train.type='custom', dataset.train.include_attribute_metadata=True, "
+            "and train.siglip_loss_dist_impl to be 'local' or 'gather'."
+        ),
+        display_name="SigLIP Loss Mask Mode",
+    )
+    triplet_loss_weight: float = FLOAT_FIELD(
+        value=0.0,
+        default_value=0.0,
+        valid_min=0.0,
+        description=(
+            "Weight for auxiliary batch-hard image-text triplet loss. "
+            "Set to 0 to disable."
+        ),
+        display_name="Triplet Loss Weight",
+    )
+    triplet_margin: float = FLOAT_FIELD(
+        value=0.2,
+        default_value=0.2,
+        valid_min=0.0,
+        description="Margin for auxiliary batch-hard image-text triplet loss.",
+        display_name="Triplet Margin",
+    )
     precision: str = STR_FIELD(
         value="fp16",
         default_value="fp16",
@@ -454,6 +562,26 @@ class CLIPInferenceEvalConfig(CLIPDataLoaderConfig):
         default_value=None,
         description="Path to text file with prompts for text embedding extraction.",
         display_name="Text File",
+    )
+
+
+@dataclass
+class CLIPEvaluateConfig(CLIPInferenceEvalConfig):
+    """Configuration specific to CLIP evaluation."""
+
+    pas_ground_truth_mode: str = STR_FIELD(
+        value="paired_caption",
+        default_value="paired_caption",
+        valid_options=(
+            "paired_caption,scalar_attributes,"
+            "scalar_plus_accessories"
+        ),
+        description=(
+            "Ground-truth policy for direct PAS text-to-image evaluation. "
+            "'paired_caption' uses exact-caption pairs; scalar modes derive "
+            "positives from exported attributes and optional accessories."
+        ),
+        display_name="PAS Ground Truth Mode",
     )
 
 
@@ -602,8 +730,8 @@ class CLIPExperimentConfig(CommonExperimentConfig):
         CLIPTrainConfig(),
         description="Training config.",
     )
-    evaluate: CLIPInferenceEvalConfig = DATACLASS_FIELD(
-        CLIPInferenceEvalConfig(),
+    evaluate: CLIPEvaluateConfig = DATACLASS_FIELD(
+        CLIPEvaluateConfig(),
         description="Evaluation config.",
     )
     inference: CLIPInferenceEvalConfig = DATACLASS_FIELD(

--- a/nvidia_tao_core/config/common/common_config.py
+++ b/nvidia_tao_core/config/common/common_config.py
@@ -27,6 +27,63 @@ class CuDNNConfig:
 
 
 @dataclass
+class CheckpointerConfig:
+    """Configuration for bounded metric-ranked checkpoint saving."""
+
+    enable_topk: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Enable best-checkpoint saving",
+        description=(
+            "Save checkpoint(s) ranked by a monitored metric. This is additive "
+            "to periodic checkpoints unless replace_periodic is enabled."
+        ),
+    )
+    replace_periodic: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Replace periodic checkpoints",
+        description=(
+            "When best-checkpoint saving is enabled, replace periodic history "
+            "with one metric-best checkpoint and its latest symlink."
+        ),
+    )
+    monitor: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        display_name="Monitored metric",
+        description="Leave unset to use the network's default metric.",
+    )
+    mode: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        valid_options="min,max",
+        display_name="Monitor mode",
+        description="Leave unset to use the network's default direction.",
+    )
+    save_top_k: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="Number of best checkpoints",
+    )
+    filename: str = STR_FIELD(
+        value="model_best_{epoch:03d}",
+        default_value="model_best_{epoch:03d}",
+        display_name="Best-checkpoint filename pattern",
+    )
+    dirpath: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description="Directory for best checkpoints. Defaults to results_dir.",
+    )
+    auto_insert_metric_name: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+    )
+
+
+@dataclass
 class TrainConfig:
     """Common train experiment config."""
 
@@ -104,6 +161,7 @@ class TrainConfig:
         description="""
         Path to where all the assets generated from a task are stored.
         """)
+    checkpointer: CheckpointerConfig = DATACLASS_FIELD(CheckpointerConfig())
 
 
 @dataclass

--- a/nvidia_tao_core/config/dino/model.py
+++ b/nvidia_tao_core/config/dino/model.py
@@ -68,6 +68,18 @@ SUPPORTED_BACKBONES = [
 class DINOModelConfig:
     """DINO model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     pretrained_backbone_path: Optional[str] = STR_FIELD(
         value=None,
         default_value="",

--- a/nvidia_tao_core/config/dinov3/__init__.py
+++ b/nvidia_tao_core/config/dinov3/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 config module."""

--- a/nvidia_tao_core/config/dinov3/default_config.py
+++ b/nvidia_tao_core/config/dinov3/default_config.py
@@ -1,0 +1,563 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 Default Config.
+
+The DINOv3 SSL family inherits aggressively from ``nvdinov2``: the dataset, head,
+distillation, scheduler, optimizer and train/inference/export schemas are reused by
+subclassing the nvdinov2 dataclasses. Only the genuinely new pieces are added here:
+
+* a v3 ``map_params`` table with **patch-16** ViT entries (vit_s, vit_s_plus, vit_b, vit_l,
+  vit_h_plus, vit_7b),
+* RoPE backbone fields (``rope_theta`` etc.) and patch-16 defaults,
+* a ``GramConfig`` for Gram anchoring (wired up in a later step), and
+* a disabled ``lora`` stub for forward-compatibility.
+
+DINOv3 is Meta IP implemented inside TAO; the family/endpoint is named ``dinov3``
+(not ``nvdinov3``). ``nvdinov2`` stays frozen.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from omegaconf import MISSING
+
+from nvidia_tao_core.config.utils.types import (
+    STR_FIELD,
+    INT_FIELD,
+    FLOAT_FIELD,
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+)
+from nvidia_tao_core.config.nvdinov2.default_config import (
+    BackboneConfig,
+    NVDINOv2HeadConfig,
+    NVDINOv2ModelDistillConfig,
+    NVDINOv2TransformConfig,
+    NVDINOv2DatasetConfig,
+    NVDINOv2TrainExpConfig,
+    NVDINOv2InferenceExpConfig,
+    NVDINOv2ExportExpConfig,
+    GenTrtEngineExpConfig,
+)
+from nvidia_tao_core.config.common.common_config import (
+    CommonExperimentConfig,
+    CuDNNConfig,
+)
+
+# DINOv3 patch-16 ViT architectures supported by the backbone config.
+SUPPORTED_BACKBONES = [
+    *["vit_s", "vit_s_plus", "vit_b", "vit_l", "vit_h_plus", "vit_7b"]
+]
+SUPPORTED_IMAGE_SIZES = (256, 512, 768)
+
+# DINOv3 ViT param map (patch-16). Distinct from the nvdinov2 (patch-14) map.
+# FFN note: DINOv3 ViT-S/B/L use a standard MLP; ViT-S+/H+/7B use SwiGLU. The
+# ``DinoV2VisionTransformer.__init__`` already accepts ``mlp_layer``, so the v3 build
+# just passes the class named here ('mlp' -> timm Mlp, 'swiglu' -> SwiGLUFused).
+map_params = {
+    'embed_dim': {
+        'vit_s': 384,
+        'vit_s_plus': 384,
+        'vit_b': 768,
+        'vit_l': 1024,
+        'vit_h_plus': 1280,
+        'vit_7b': 4096,
+    },
+    'depth': {
+        'vit_s': 12,
+        'vit_s_plus': 12,
+        'vit_b': 12,
+        'vit_l': 24,
+        'vit_h_plus': 32,
+        'vit_7b': 40,
+    },
+    'num_heads': {
+        'vit_s': 6,
+        'vit_s_plus': 6,
+        'vit_b': 12,
+        'vit_l': 16,
+        'vit_h_plus': 20,
+        'vit_7b': 32,
+    },
+    'init_values': {
+        'vit_s': 1e-5,
+        'vit_s_plus': 1e-5,
+        'vit_b': 1e-5,
+        'vit_l': 1e-5,
+        'vit_h_plus': 1e-5,
+        'vit_7b': 1e-5,
+    },
+    'drop_path_schedule': {
+        'vit_s': 'linear',
+        'vit_s_plus': 'linear',
+        'vit_b': 'linear',
+        'vit_l': 'linear',
+        'vit_h_plus': 'linear',
+        'vit_7b': 'linear',
+    },
+    'num_classes': {
+        'vit_s': 0,
+        'vit_s_plus': 0,
+        'vit_b': 0,
+        'vit_l': 0,
+        'vit_h_plus': 0,
+        'vit_7b': 0,
+    },
+    'mlp_layer': {
+        'vit_s': 'mlp',
+        'vit_s_plus': 'swiglu',
+        'vit_b': 'mlp',
+        'vit_l': 'mlp',
+        'vit_h_plus': 'swiglu',
+        'vit_7b': 'swiglu',
+    },
+    # SwiGLU inner width = mlp_ratio * embed_dim per gate/value branch. ViT-S+/B/L/H+ use 4.0
+    # (timm default); the public DINOv3 ViT-7B checkpoint uses 2.0. Verified against timm
+    # 1.0.26 `vit_7b_patch16_dinov3` (eva.py), which sets `mlp_ratio=2` explicitly while H+
+    # leaves it at the EVA default of 4.0. With swiglu_align_to=64 this yields fc1_g/fc1_x of
+    # (8192, 4096) each, i.e. 2*dim, matching `fuse_timm_swiglu_fc1`'s expected fused shape.
+    # Threaded into the backbone build via _resolve_arch.
+    'mlp_ratio': {
+        'vit_s': 4.0,
+        'vit_s_plus': 4.0,
+        'vit_b': 4.0,
+        'vit_l': 4.0,
+        'vit_h_plus': 4.0,
+        'vit_7b': 2.0,
+    },
+}
+
+
+@dataclass
+class DINOv3BackboneConfig(BackboneConfig):
+    """DINOv3 backbone config (patch-16 + RoPE).
+
+    Subclasses the nvdinov2 ``BackboneConfig`` and overrides the patch-16 defaults,
+    the ViT-B default backbone type, and adds the RoPE frequency base. The absolute
+    positional embedding of DINOv2 is replaced by axial RoPE, so there is no
+    ``pos_embed`` field; the ``DinoV3VisionTransformer`` does not register one.
+    """
+
+    teacher_type: str = STR_FIELD(
+        value="vit_b",
+        default_value="vit_b",
+        display_name="teacher backbone",
+        description=(
+            "Teacher backbone name. TAO's DINOv3 supports vit_s, vit_s_plus, vit_b, vit_l, vit_h_plus and vit_7b."
+        ),
+        valid_options=",".join(SUPPORTED_BACKBONES),
+        popular="no"
+    )
+    student_type: str = STR_FIELD(
+        value="vit_b",
+        default_value="vit_b",
+        display_name="student backbone",
+        description=(
+            "Student backbone name. TAO's DINOv3 supports vit_s, vit_s_plus, vit_b, vit_l, vit_h_plus and vit_7b."
+        ),
+        valid_options=",".join(SUPPORTED_BACKBONES),
+        popular="no"
+    )
+    num_register_tokens: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=0,
+        valid_max="inf",
+        description="Number of register tokens (DINOv3 ViT-B uses 4)",
+        display_name="num register tokens",
+        popular="yes"
+    )
+    patch_size: int = INT_FIELD(
+        value=16,
+        default_value=16,
+        description="Size of patches (DINOv3 uses patch 16)",
+        display_name="patch size",
+        valid_options="16",
+        popular="yes"
+    )
+    img_size: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        description="Backbone image size. Supported values are 256, 512, and 768.",
+        display_name="image size",
+        valid_options=",".join(str(size) for size in SUPPORTED_IMAGE_SIZES),
+        popular="yes"
+    )
+    rope_theta: float = FLOAT_FIELD(
+        value=100.0,
+        default_value=100.0,
+        description=(
+            "Frequency base for 2D axial RoPE. Must match the timm DINOv3 reference; "
+            "verified by the step-4 feature-parity smoke test."
+        ),
+        display_name="RoPE theta",
+        popular="yes"
+    )
+
+
+@dataclass
+class GramConfig:
+    """DINOv3 Gram-anchoring config.
+
+    Gram anchoring regularizes the student's patch-token Gram matrix toward a frozen
+    Gram teacher (initialized from the loaded DINOv3 weights). The loss term itself is
+    wired in a later step; these fields configure when/how strongly it applies.
+    """
+
+    enable: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Whether to add the Gram-anchoring loss term",
+        display_name="enable gram",
+        popular="yes"
+    )
+    w_gram: float = FLOAT_FIELD(
+        value=0.0,
+        default_value=0.0,
+        description="Weight of the Gram-anchoring loss term",
+        display_name="gram weight",
+        popular="yes"
+    )
+    start_step: int = INT_FIELD(
+        value=0,
+        default_value=0,
+        valid_min=0,
+        valid_max="inf",
+        description="Global step at which the Gram term activates",
+        display_name="gram start step",
+        popular="yes"
+    )
+    teacher_source: str = STR_FIELD(
+        value="pretrained",
+        default_value="pretrained",
+        description=(
+            "Source of the frozen Gram teacher weights: 'pretrained' anchors to the loaded "
+            "DINOv3 weights (Phase 0 default); 'ema' uses an early-EMA snapshot of the current "
+            "run's teacher, refreshed every 'refresh_interval' steps (Phase 1 / high-res)."
+        ),
+        display_name="gram teacher source",
+        valid_options="pretrained,ema",
+        popular="no"
+    )
+    refresh_interval: int = INT_FIELD(
+        value=0,
+        default_value=0,
+        valid_min=0,
+        valid_max="inf",
+        description=(
+            "Steps between refreshing the Gram teacher from the EMA teacher (only when "
+            "teacher_source='ema'). 0 = never refresh (frozen snapshot, Phase 0 behavior)."
+        ),
+        display_name="gram refresh interval",
+        popular="no"
+    )
+    teacher_scale: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        description=(
+            "Resolution multiple at which the Gram teacher runs relative to the student. "
+            "DINOv3 computes Gram on higher-res teacher features; the teacher grid is "
+            "average-pooled back to the student grid before the loss. 1.0 = same resolution "
+            "(default, memory-safe). The paper uses 2.0, but at 768 the teacher then runs at "
+            "1536 (96x96=9216 tokens) -> heavy; raise to 1.5/2.0 only if memory allows."
+        ),
+        display_name="gram teacher scale",
+        popular="no"
+    )
+
+
+@dataclass
+class LoRAConfig:
+    """Disabled LoRA stub for forward-compatibility (parameter-efficient SSL, Phase 2)."""
+
+    enable: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Whether to apply LoRA adapters (disabled in v1)",
+        display_name="enable lora",
+        popular="no"
+    )
+    rank: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        valid_max="inf",
+        description="LoRA rank",
+        display_name="lora rank",
+        popular="no"
+    )
+    alpha: float = FLOAT_FIELD(
+        value=16.0,
+        default_value=16.0,
+        description="LoRA scaling alpha",
+        display_name="lora alpha",
+        popular="no"
+    )
+
+
+@dataclass
+class DINOv3ModelConfig:
+    """DINOv3 model config (reuses nvdinov2 distill/head, adds gram + lora)."""
+
+    centering_method: str = STR_FIELD(
+        value="sinkhorn",
+        default_value="sinkhorn",
+        valid_options="sinkhorn,softmax",
+        description=(
+            "Teacher-output centering for the DINO/iBOT heads. DINOv3 uses Sinkhorn-Knopp "
+            "(SwAV); 'softmax' is the DINOv2 fallback. If training shows instability/collapse, "
+            "try 'softmax'."
+        ),
+        display_name="centering method",
+        popular="yes"
+    )
+    distill: NVDINOv2ModelDistillConfig = DATACLASS_FIELD(
+        NVDINOv2ModelDistillConfig(),
+        description="Configuration for distillation (reused from nvdinov2)"
+    )
+    backbone: DINOv3BackboneConfig = DATACLASS_FIELD(
+        DINOv3BackboneConfig(),
+        description="Configuration for the DINOv3 backbone"
+    )
+    head: NVDINOv2HeadConfig = DATACLASS_FIELD(
+        NVDINOv2HeadConfig(),
+        description="Configuration for the DINOv3 head (reused from nvdinov2)"
+    )
+    gram: GramConfig = DATACLASS_FIELD(
+        GramConfig(),
+        description="Configuration for DINOv3 Gram anchoring"
+    )
+    lora: LoRAConfig = DATACLASS_FIELD(
+        LoRAConfig(),
+        description="Disabled LoRA stub for forward-compatibility"
+    )
+
+
+@dataclass
+class DINOv3TransformConfig(NVDINOv2TransformConfig):
+    """DINOv3 transform config with a 256 default and patch-16-friendly crop sizes."""
+
+    global_crops_size: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        valid_min=1,
+        valid_max="inf",
+        description="Size of global crops for DINOv3 training.",
+        display_name="Global Crops Size",
+        popular="yes"
+    )
+    local_crops_size: int = INT_FIELD(
+        value=112,
+        default_value=112,
+        valid_min=1,
+        valid_max="inf",
+        description="Size of local crops (multiple of patch 16)",
+        display_name="Local Crops Size",
+        popular="yes"
+    )
+
+
+@dataclass
+class DINOv3DatasetConfig(NVDINOv2DatasetConfig):
+    """DINOv3 dataset config (reuses nvdinov2 dataset, v3 transform defaults)."""
+
+    transform: DINOv3TransformConfig = DATACLASS_FIELD(
+        DINOv3TransformConfig(),
+        description="Configuration parameters for data transformation",
+        display_name="transform",
+    )
+
+
+@dataclass
+class DINOv3CuDNNConfig(CuDNNConfig):
+    """CuDNN defaults compatible with DINOv3 custom attention."""
+
+    benchmark: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        description="Enable CuDNN benchmarking for DINOv3 training.",
+        display_name="CuDNN benchmark",
+        popular="no",
+    )
+    deterministic: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Enable deterministic CuDNN behavior. Keep disabled when using "
+            "DINOv3 custom attention, which has no deterministic backward implementation."
+        ),
+        display_name="CuDNN deterministic",
+        popular="no",
+    )
+
+
+@dataclass
+class DINOv3TrainExpConfig(NVDINOv2TrainExpConfig):
+    """DINOv3 train config.
+
+    Subclasses the nvdinov2 train config, selects CuDNN defaults compatible with
+    custom attention, corrects the inherited pretrained-weight contract, and adds
+    a ``distributed_strategy`` selector. The nvdinov2 default
+    (Lightning ``'auto'`` -> single-device / DDP) is unchanged; FSDP (FULL_SHARD) is
+    opt-in and is what enables high-resolution and the larger ViT-L / ViT-H+ backbones,
+    where DDP's full per-GPU replication does not fit. The ``DINOV3_STRATEGY`` env var,
+    kept for the de-risking smokes, overrides this field when set.
+    """
+
+    pretrained_model_path: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        default_type=None,
+        description=(
+            "Path to DINOv3 pretrained weights matching the configured backbone. "
+            "Accepts a timm-format directory or file, or a stripped TAO DINOv3 "
+            "backbone checkpoint. DINOv2/NVDINOv2 checkpoints are not supported."
+        )
+    )
+    distributed_strategy: str = STR_FIELD(
+        value="auto",
+        default_value="auto",
+        valid_options="auto,ddp,fsdp",
+        description=(
+            "Lightning distributed strategy. 'auto' keeps the nvdinov2 behaviour "
+            "(single-device or DDP). 'fsdp' shards params/grads/optimizer (FULL_SHARD) "
+            "for high-resolution and large-backbone multi-GPU training."
+        ),
+        display_name="distributed strategy",
+        popular="yes"
+    )
+    cudnn: DINOv3CuDNNConfig = DATACLASS_FIELD(
+        DINOv3CuDNNConfig(),
+        description="CuDNN settings compatible with DINOv3 custom attention.",
+    )
+
+
+@dataclass
+class DINOv3ExportExpConfig(NVDINOv2ExportExpConfig):
+    """DINOv3 export config (patch-16 trace shape).
+
+    Overrides the nvdinov2 default ONNX trace shape (518, a patch-14 multiple):
+    DINOv3 is patch-16 and defaults to 256, so the default trace matches the backbone
+    ``img_size`` and stays divisible by the patch size.
+    """
+
+    checkpoint: str = STR_FIELD(
+        value=MISSING,
+        default_value="",
+        description=(
+            "Path to a stripped DINOv3 teacher checkpoint or a full Lightning training "
+            "checkpoint. Export always selects the EMA teacher backbone."
+        ),
+        display_name="Path to checkpoint file"
+    )
+    input_width: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        description="Input width",
+        display_name="Input width",
+        valid_min=128
+    )
+    input_height: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        description="Input height",
+        display_name="Input height",
+        valid_min=128
+    )
+
+
+@dataclass
+class DINOv3ConvertConfig:
+    """DINOv3 backbone-export (``convert``) config.
+
+    Converts an SSL-trained DINOv3 checkpoint into the timm-format layout that the
+    ``cv/backbone_v2`` ``dinov3_vitb16`` registry entry (and downstream supervised tasks)
+    consume. The EMA ``teacher`` is the recommended feature extractor for continual
+    pre-training, so it is the default source.
+    """
+
+    results_dir: Optional[str] = STR_FIELD(
+        value=None,
+        default_value="",
+        description="Directory for convert results/logs",
+        display_name="results dir"
+    )
+    checkpoint: str = STR_FIELD(
+        value="",
+        default_value="",
+        description=(
+            "SSL DINOv3 checkpoint to convert: a stripped backbone file "
+            "(student_*.pth / teacher_*.pth) or a full Lightning .pth/.ckpt."
+        ),
+        display_name="checkpoint",
+        popular="yes"
+    )
+    output_path: str = STR_FIELD(
+        value="",
+        default_value="",
+        description=(
+            "Output path for the timm-format backbone (.safetensors or .pth). Defaults to "
+            "<results_dir>/dinov3_<arch>_backbone.safetensors."
+        ),
+        display_name="output path",
+        popular="yes"
+    )
+    source: str = STR_FIELD(
+        value="teacher",
+        default_value="teacher",
+        valid_options="student,teacher,student_ema",
+        description="Which SSL sub-model's backbone to export (EMA teacher recommended).",
+        display_name="source",
+        popular="yes"
+    )
+    validate: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        description="Validate the converted state dict against a fresh timm DINOv3 model.",
+        display_name="validate"
+    )
+
+
+@dataclass
+class ExperimentConfig(CommonExperimentConfig):
+    """DINOv3 experiment config."""
+
+    model: DINOv3ModelConfig = DATACLASS_FIELD(
+        DINOv3ModelConfig(),
+        description="Configurable parameters to construct the model for a DINOv3 experiment.",
+    )
+    dataset: DINOv3DatasetConfig = DATACLASS_FIELD(
+        DINOv3DatasetConfig(),
+        description="Configurable parameters to construct the dataset for a DINOv3 experiment.",
+    )
+    train: DINOv3TrainExpConfig = DATACLASS_FIELD(
+        DINOv3TrainExpConfig(),
+        description="Configurable parameters to construct the trainer for a DINOv3 experiment.",
+    )
+    inference: NVDINOv2InferenceExpConfig = DATACLASS_FIELD(
+        NVDINOv2InferenceExpConfig(),
+        description="Configurable parameters to construct the inference trainer for a DINOv3 experiment.",
+    )
+    export: DINOv3ExportExpConfig = DATACLASS_FIELD(
+        DINOv3ExportExpConfig(),
+        description="Configurable parameters to export for a DINOv3 experiment.",
+    )
+    gen_trt_engine: GenTrtEngineExpConfig = DATACLASS_FIELD(
+        GenTrtEngineExpConfig(),
+        description="Configurable parameters to generate TensorRT engine for a DINOv3 experiment.",
+    )
+    convert: DINOv3ConvertConfig = DATACLASS_FIELD(
+        DINOv3ConvertConfig(),
+        description="Configurable parameters to convert an SSL backbone to the backbone_v2 (timm) layout.",
+    )
+
+    def __post_init__(self):
+        """Set default model name for DINOv3."""
+        if self.model_name is None:
+            self.model_name = "dinov3"
+
+
+# Expose a single MLP-layer registry so the pl_model resolves the param-map string
+# ('mlp'/'swiglu') without importing torch at config-parse time.
+MLP_LAYER_NAMES = ("mlp", "swiglu")

--- a/nvidia_tao_core/config/grounding_dino/dataset.py
+++ b/nvidia_tao_core/config/grounding_dino/dataset.py
@@ -223,6 +223,18 @@ class GDINODatasetConfig:
         valid_max="inf",
         display_name="max labels"
     )
+    deterministic_label_order: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="deterministic label order",
+        description=(
+            "If True, canonicalize the per-sample caption/label order with sorted() so that the "
+            "caption token order is reproducible across process launches, independent of the "
+            "PYTHONHASHSEED that governs Python set-iteration order. The seeded per-item shuffle "
+            "still provides caption-order augmentation diversity; only the hash-seed dependence is "
+            "removed. Set False to restore the legacy (non-deterministic) set-iteration order."
+        )
+    )
     eval_class_ids: Optional[List[int]] = LIST_FIELD(
         arrList=None,
         default_value=[1],

--- a/nvidia_tao_core/config/mask2former/model.py
+++ b/nvidia_tao_core/config/mask2former/model.py
@@ -368,6 +368,18 @@ class Backbone:
 class Mask2FormerModelConfig:
     """Mask2former model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     export: bool = BOOL_FIELD(
         value=False,
         default_value=False,

--- a/nvidia_tao_core/config/nvdinov2/default_config.py
+++ b/nvidia_tao_core/config/nvdinov2/default_config.py
@@ -72,7 +72,7 @@ class DataPathFormat:
     images_dir: str = STR_FIELD(
         value="",
         default_value="",
-        description="Path to images directory for dataset",
+        description="Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
         display_name="image directory"
     )
 

--- a/nvidia_tao_core/config/nvpanoptix3d/model.py
+++ b/nvidia_tao_core/config/nvpanoptix3d/model.py
@@ -356,6 +356,18 @@ class Projection:
 class NVPanoptix3DModelConfig:
     """NVPanoptix3D model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     backbone: Backbone = DATACLASS_FIELD(
         Backbone(),
         description="Configuration hyper parameters for the NVPanoptix3D Backbone.",

--- a/nvidia_tao_core/config/oneformer/model.py
+++ b/nvidia_tao_core/config/oneformer/model.py
@@ -636,6 +636,18 @@ class TextEncoder:
 class OneFormerModelConfig:
     """OneFormer model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     sem_seg_head: SemanticSegmentationHead = DATACLASS_FIELD(
         SemanticSegmentationHead(),
         description="Semantic segmentation head.",

--- a/nvidia_tao_core/config/rtdetr/model.py
+++ b/nvidia_tao_core/config/rtdetr/model.py
@@ -95,6 +95,18 @@ class FrozenFMConfig:
 class RTModelConfig:
     """RT-DETR model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     pretrained_backbone_path: Optional[str] = STR_FIELD(
         value=None,
         default_value="",

--- a/nvidia_tao_core/config/segformer/default_config.py
+++ b/nvidia_tao_core/config/segformer/default_config.py
@@ -128,6 +128,11 @@ class BackboneConfig:
             "fan_base_16_p4_hybrid",
             "vit_large_nvdinov2",
             "vit_giant_nvdinov2",
+            "vit_small_dinov3",
+            "vit_small_plus_dinov3",
+            "vit_base_dinov3",
+            "vit_large_dinov3",
+            "vit_huge_plus_dinov3",
             "vit_base_nvclip_16_siglip",
             "vit_huge_nvclip_14_siglip"
         ]),
@@ -155,6 +160,18 @@ class BackboneConfig:
 class SFModelConfig:
     """SF Model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="Deterministic MSDeformAttn",
+        description=(
+            "When True, route MultiScaleDeformableAttention through the deterministic "
+            "pure-PyTorch implementation instead of the custom CUDA op, whose atomicAdd "
+            "backward has no deterministic kernel. Combined with train.cudnn.deterministic "
+            "this yields reproducible training, at some speed/memory cost. Default False "
+            "(fused CUDA op, current behavior)."
+        ),
+    )
     backbone: BackboneConfig = DATACLASS_FIELD(BackboneConfig())
     decode_head: SegFormerHeadConfig = DATACLASS_FIELD(SegFormerHeadConfig())
 

--- a/nvidia_tao_core/config/visual_changenet/default_config.py
+++ b/nvidia_tao_core/config/visual_changenet/default_config.py
@@ -130,7 +130,8 @@ class BackboneConfig:
         display_name="Backbone architectures",
         valid_options=(
             "fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,"
-            "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2"
+            "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,"
+            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3"
         )
     )
     feat_downsample: bool = BOOL_FIELD(

--- a/nvidia_tao_core/microservices/automl/controller.py
+++ b/nvidia_tao_core/microservices/automl/controller.py
@@ -50,12 +50,15 @@ from nvidia_tao_core.microservices.utils.stateless_handler_utils import (
     delete_dnn_status,
     update_automl_stats,
     report_health_beat,
-    delete_health_beat
+    delete_health_beat,
+    get_automl_child_job_ids,
+    reset_automl_child_lifecycle_for_resume,
+    set_automl_checkpoint_cleanup_state,
 )
 from nvidia_tao_core.microservices.utils.automl_job_utils import (
     on_new_automl_job,
     on_delete_automl_job,
-    on_cancel_automl_job
+    cancel_automl_child_job,
 )
 # Configure logging
 TAO_LOG_LEVEL = os.getenv('TAO_LOG_LEVEL', 'INFO').upper()
@@ -160,6 +163,10 @@ class Controller:
 
         self.old_bracket = "0"
         self.hyperband_cancel_condition_seen = False
+        job_metadata = get_handler_job_metadata(self.automl_context.id) or {}
+        self._checkpoint_cleanup_pending = bool(
+            job_metadata.get("checkpoint_cleanup_pending", False)
+        )
 
         self.wandb_group_name = f"automl_{self.automl_context.id}"
         self.parameter_names = list(parameter_names) if parameter_names else []
@@ -433,14 +440,27 @@ class Controller:
     def cancel_recommendation_jobs(self):
         """Cleanup recommendation jobs"""
         backend = os.getenv("TAO_EXECUTION_BACKEND", "local-k8s")
+        all_children_stopped = True
+        known_child_ids = set()
         for rec in self.recommendations:
             job_name = rec.job_id
             logger.info("Deleting %s", job_name)
             if not job_name:
                 continue
+            known_child_ids.add(job_name)
             if not os.getenv("CI_PROJECT_DIR", None):
                 logger.info("Cancelling automl job at end of controller %s", job_name)
-                on_cancel_automl_job(rec.job_id)
+                cancel_result = cancel_automl_child_job(rec.job_id)
+                if cancel_result is not True:
+                    all_children_stopped = False
+                    logger.warning(
+                        "Could not confirm termination of AutoML child job %s; "
+                        "retaining its checkpoint artifacts",
+                        job_name,
+                    )
+            else:
+                # A test/CI shortcut is not proof that a real writer is absent.
+                all_children_stopped = False
 
             # Stop log monitoring for this experiment
             if backend in ("local-k8s", "local-docker"):
@@ -452,8 +472,166 @@ class Controller:
                 except Exception as e:
                     logger.warning(f"[AUTOML-CONTROLLER] Failed to stop log monitoring for {job_name}: {e}")
 
+        # Include workflow children that were durably enqueued but were not yet
+        # present in the controller's in-memory recommendation snapshot.
+        for child_job_id in set(
+            get_automl_child_job_ids(self.automl_context.id)
+        ) - known_child_ids:
+            if cancel_automl_child_job(child_job_id) is not True:
+                all_children_stopped = False
+
+        cleanup_complete = not self._checkpoint_cleanup_pending
+        if self._checkpoint_cleanup_pending and all_children_stopped:
+            try:
+                # Child jobs have now been stopped, so bind-mounted artifacts are no longer
+                # being written and platform ownership repair has had a chance to run.
+                set_automl_checkpoint_cleanup_state(
+                    self.automl_context.id, "cleaning"
+                )
+                cleanup_complete = self._cleanup_checkpoints_on_cancellation()
+            except Exception as err:
+                cleanup_complete = False
+                logger.warning(
+                    "Unexpected checkpoint cleanup failure for canceled AutoML job %s: %s",
+                    self.automl_context.id, err
+                )
+                set_automl_checkpoint_cleanup_state(
+                    self.automl_context.id, "pending", error=err
+                )
+            if cleanup_complete and set_automl_checkpoint_cleanup_state(
+                self.automl_context.id, "complete"
+            ):
+                self._checkpoint_cleanup_pending = False
+            else:
+                cleanup_complete = False
+                self._checkpoint_cleanup_pending = True
+                set_automl_checkpoint_cleanup_state(
+                    self.automl_context.id,
+                    "pending",
+                    error="one or more checkpoint artifacts could not be removed",
+                )
+        elif self._checkpoint_cleanup_pending:
+            logger.warning(
+                "Skipping checkpoint cleanup for AutoML job %s because one or "
+                "more child writers were not confirmed stopped",
+                self.automl_context.id,
+            )
+
+        if not all_children_stopped or not cleanup_complete:
+            logger.warning(
+                "Retaining AutoML controller %s so child cancellation and "
+                "artifact cleanup can be retried",
+                self.automl_context.id,
+            )
+            return False
+
         logger.info("Deleting automl job %s", self.automl_context.id)
         on_delete_automl_job(self.automl_context.id)
+        return all_children_stopped
+
+    def _schedule_checkpoint_cleanup(self):
+        """Durably request cancellation cleanup before stopping any child."""
+        self._checkpoint_cleanup_pending = True
+        if not set_automl_checkpoint_cleanup_state(
+            self.automl_context.id, "pending"
+        ):
+            logger.error(
+                "Unable to persist checkpoint cleanup intent for AutoML job %s",
+                self.automl_context.id,
+            )
+            return False
+        return True
+
+    def _finish_pending_checkpoint_cleanup(self):
+        """Retry cancellation until all launchers and artifact deletes are quiescent."""
+        while True:
+            if self.cancel_recommendation_jobs() is not False:
+                return True
+            report_health_beat(
+                self.automl_context.id,
+                "Waiting for AutoML child quiescence and checkpoint cleanup retry",
+            )
+            time.sleep(5)
+
+    def _cleanup_checkpoints_on_cancellation(self):
+        """Delete checkpoint artifacts that cannot be used after AutoML cancellation.
+
+        The controller can observe the parent job's canceled state before ``read_results``
+        gets another opportunity to run its normal checkpoint cleanup. Preserve the best
+        completed recommendation while removing artifacts from the remaining recommendations.
+        Paused jobs never enter this terminal cleanup path, so their resume sources remain intact.
+        """
+        if not self.delete_intermediate_ckpt:
+            logger.info(
+                "Skipping checkpoint cleanup for canceled AutoML job %s because "
+                "automl_delete_intermediate_ckpt is disabled",
+                self.automl_context.id
+            )
+            return True
+
+        try:
+            self.refresh_recommendations()
+        except Exception as err:
+            logger.warning(
+                "Unable to refresh recommendations before cancellation cleanup for AutoML job %s: %s",
+                self.automl_context.id, err
+            )
+            return False
+
+        successful_recs = [
+            rec for rec in self.recommendations if rec.status == JobStates.success
+        ]
+        best_rec_id = None
+        if successful_recs:
+            try:
+                best_rec_id = self.min_max(successful_recs, key=lambda rec: rec.result).id
+            except Exception as err:
+                # Failing closed here avoids deleting a potentially best checkpoint.
+                logger.warning(
+                    "Unable to identify the best recommendation during cancellation cleanup "
+                    "for AutoML job %s; preserving completed recommendations: %s",
+                    self.automl_context.id, err
+                )
+
+        # Pause deliberately skips terminal cleanup and is the supported resume
+        # path. Once the parent is canceled, errored, or completed, promotion
+        # sources are no longer live dependencies; retaining every successful
+        # Hyperband/ASHA/PBT trial would recreate the disk-exhaustion issue.
+
+        all_artifacts_cleaned = True
+        for rec in self.recommendations:
+            if not rec.job_id:
+                continue
+
+            try:
+                expt_root = self._get_experiment_results_path(rec.job_id)
+                if rec.id == best_rec_id:
+                    # Retain the selected best checkpoint, but discard its intermediate saves.
+                    if self.delete_checkpoint_files(
+                        expt_root, rec, retain_resume_checkpoint=False
+                    ) is False:
+                        all_artifacts_cleaned = False
+                elif best_rec_id is None and rec.status == JobStates.success:
+                    # If best selection failed, preserve all successful recommendations.
+                    logger.info(
+                        "Preserving successful recommendation %s because the current best "
+                        "could not be determined",
+                        rec.id
+                    )
+                else:
+                    self.delete_not_best_model_checkpoints(expt_root, rec, True)
+                    if not getattr(
+                        self, "_last_checkpoint_delete_verified", True
+                    ):
+                        all_artifacts_cleaned = False
+            except Exception as err:
+                all_artifacts_cleaned = False
+                logger.warning(
+                    "Failed to clean checkpoint artifacts for canceled AutoML recommendation %s "
+                    "(job %s): %s",
+                    rec.id, rec.job_id, err
+                )
+        return all_artifacts_cleaned
 
     def start(self):
         """Starts the automl controller"""
@@ -478,8 +656,17 @@ class Controller:
                 "AutoML train started, more details in automl_brain_info of response"
             )
             self._execute_loop()
+            result_metadata = get_handler_job_metadata(self.automl_context.id) or {}
+            current_status = str(result_metadata.get("status", "")).lower()
+            if self._checkpoint_cleanup_pending or current_status in ("canceled", "canceling"):
+                # Preserve the externally managed cancellation state. Child shutdown also
+                # performs the deferred, ownership-safe checkpoint cleanup.
+                self._schedule_checkpoint_cleanup()
+                self._finish_pending_checkpoint_cleanup()
+                delete_health_beat(self.automl_context.id)
+                return
+
             status = "Error"
-            result_metadata = get_handler_job_metadata(self.automl_context.id)
             best_model_path = self._get_experiment_results_path(self.automl_context.id)
             result_metadata["job_details"][self.automl_context.id] = {
                 "detailed_status": {
@@ -568,9 +755,25 @@ class Controller:
                         }
                     }
 
+            # Final pruning is a durable phase, separate from best-model
+            # handoff. This covers parallel algorithms such as ASHA whose trial
+            # checkpoints may not have been incrementally pruned.
+            # Do not let the older metadata snapshot overwrite the fresh
+            # cleanup handshake fields written below.
+            for cleanup_key in (
+                "checkpoint_cleanup_pending",
+                "checkpoint_cleanup_status",
+                "checkpoint_cleanup_error",
+                "checkpoint_cleanup_updated_at",
+            ):
+                result_metadata.pop(cleanup_key, None)
+            if not self._schedule_checkpoint_cleanup():
+                raise RuntimeError(
+                    "Unable to persist terminal AutoML checkpoint cleanup intent"
+                )
             write_job_metadata(self.automl_context.id, result_metadata)
             update_job_status(self.automl_context.handler_id, self.automl_context.id, status=status, kind="experiments")
-            self.cancel_recommendation_jobs()
+            self._finish_pending_checkpoint_cleanup()
 
             # Final WandB table update
             if self.wandb_initialized:
@@ -590,21 +793,31 @@ class Controller:
                 "AutoMLpipeline loop for network %s with job id %s failed due to exception %s",
                 self.network, self.automl_context.id, traceback.format_exc()
             )
-            result_metadata = get_handler_job_metadata(self.automl_context.id)
-            result_metadata["job_details"][self.automl_context.id] = {
-                "detailed_status": {
-                    "message": "AutoML train failed due to run-time exception",
-                    "status": "FAILURE"
-                }
-            }
-            write_job_metadata(self.automl_context.id, result_metadata)
-            self.cancel_recommendation_jobs()
-            update_job_status(
-                self.automl_context.handler_id,
-                self.automl_context.id,
-                status="Error",
-                kind="experiments"
+            result_metadata = get_handler_job_metadata(self.automl_context.id) or {}
+            current_status = str(result_metadata.get("status", "")).lower()
+            cancellation_in_progress = (
+                self._checkpoint_cleanup_pending or current_status in ("canceled", "canceling")
             )
+            if not cancellation_in_progress:
+                result_metadata["job_details"][self.automl_context.id] = {
+                    "detailed_status": {
+                        "message": "AutoML train failed due to run-time exception",
+                        "status": "FAILURE"
+                    }
+                }
+                write_job_metadata(self.automl_context.id, result_metadata)
+
+            # Abnormal exits bypass read_results just like cancellation exits. Schedule
+            # eligible cleanup before stopping children; the deletion flag still controls it.
+            self._schedule_checkpoint_cleanup()
+            self._finish_pending_checkpoint_cleanup()
+            if not cancellation_in_progress:
+                update_job_status(
+                    self.automl_context.handler_id,
+                    self.automl_context.id,
+                    status="Error",
+                    kind="experiments"
+                )
 
             # Clean up WandB on error
             if self.wandb_initialized:
@@ -759,14 +972,7 @@ class Controller:
             f"automl_job_id={automl_context.id}, temp_rec={temp_rec}, "
             f"num_recommendations={len(ctrl.recommendations)}"
         )
-        # if ctrl.recommendations[temp_rec].status != JobStates.canceled:
-        #     ctrl.recommendations[temp_rec].update_status(JobStates.success)
         ctrl.save_state()
-        if ctrl.recommendations[temp_rec].status == JobStates.canceled:
-            logger.info("Resuming stopped automl sub-experiment %s", temp_rec)
-            if ctrl.automl_algorithm in ("hyperband", "bohb", "asha", "dehb", "hyperband_es", "hes"):
-                ctrl.brain.track_id = temp_rec
-            ctrl.on_new_automl_job(ctrl.recommendations[temp_rec])
 
         if temp_rec is not None and temp_rec < len(ctrl.recommendations):
             rec_status = ctrl.recommendations[temp_rec].status
@@ -776,6 +982,12 @@ class Controller:
                 f"is_canceled={rec_status == JobStates.canceled}"
             )
             if rec_status == JobStates.canceled:
+                child_job_id = ctrl.recommendations[temp_rec].job_id
+                if not reset_automl_child_lifecycle_for_resume(child_job_id):
+                    raise RuntimeError(
+                        "AutoML child cancellation fence could not be reset for "
+                        f"paused recommendation {child_job_id}"
+                    )
                 logger.debug(
                     f"[CONTROLLER-LOAD-STATE] Resuming stopped automl sub-experiment: "
                     f"automl_job_id={automl_context.id}, rec_id={temp_rec}, "
@@ -829,10 +1041,13 @@ class Controller:
                 f"{self.automl_algorithm_settings.automl_max_recommendations})"
             )
 
-            metadata = get_handler_job_metadata(self.automl_context.id)
-            current_status = metadata.get("status", "")
+            metadata = get_handler_job_metadata(self.automl_context.id) or {}
+            current_status = str(metadata.get("status", "")).lower()
             automl_status = get_automl_controller_info(self.automl_context.id)
             if current_status in ("canceled", "canceling"):
+                # Defer storage cleanup until cancel_recommendation_jobs has stopped every
+                # child process. This avoids racing checkpoint writers and ownership repair.
+                self._schedule_checkpoint_cleanup()
                 return
             if automl_status:
                 self.completed_recommendations = len(automl_status)
@@ -874,12 +1089,10 @@ class Controller:
                     logger.info("best_model_copied result %s", self.best_model_copied)
 
                     if self.best_model_copied:
-                        # Delete final extra checkpoints after finish training
-                        for rec in self.recommendations:
-                            expt_root = self._get_experiment_results_path(rec.job_id)
-                            self.get_best_checkpoint_path(expt_root, rec)
-                            if self.delete_intermediate_ckpt:
-                                self.delete_not_best_model_checkpoints(expt_root, rec, True)
+                        # Trial pruning happens after final status construction via
+                        # the durable cleanup barrier in ``start``. Do not delete
+                        # here: child writers and remote storage acknowledgements
+                        # have not yet been joined into one terminal barrier.
                         handler_metadata = get_handler_metadata(
                             self.automl_context.handler_id, "experiments"
                         )
@@ -1131,6 +1344,18 @@ class Controller:
                     f"automl_job_id={self.automl_context.id}, rec_id={rec_id}, "
                     f"rec_job_id={self.recommendations[rec_id].job_id}"
                 )
+                # Multi-fidelity promotions intentionally reuse the same child
+                # job ID and checkpoint directory. read_results fenced and
+                # quiesced the prior writer before inspecting its checkpoint;
+                # explicitly re-arm that identity for this one promoted launch.
+                # A concurrent parent Canceling/Paused state is still checked by
+                # AutoMLPipeline before and after its atomic launch claim.
+                child_job_id = self.recommendations[rec_id].job_id
+                if not reset_automl_child_lifecycle_for_resume(child_job_id):
+                    raise RuntimeError(
+                        "AutoML child cancellation fence could not be reset for "
+                        f"promoted recommendation {child_job_id}"
+                    )
                 self.on_new_automl_job(self.recommendations[rec_id])
                 logger.debug(
                     f"[AUTOML-CONTROLLER-RESUME] Resume recommendation processing completed: "
@@ -1144,6 +1369,7 @@ class Controller:
         flag = False
         self.refresh_recommendations()
         for rec in self.recommendations:
+            child_quiescent = True
             # Report health beat for each experiment being processed
             report_health_beat(
                 self.automl_context.id,
@@ -1164,6 +1390,14 @@ class Controller:
 
             # If rec already changed to Success, no need to check
             if rec.status in [JobStates.success, JobStates.failure]:
+                child_quiescent = cancel_automl_child_job(rec.job_id) is True
+                if not child_quiescent:
+                    logger.warning(
+                        "Deferring checkpoint cleanup for completed AutoML child %s "
+                        "until backend quiescence is confirmed",
+                        rec.job_id,
+                    )
+                    continue
                 # Apply penalty for failed experiments if result is still 0.0
                 if rec.status == JobStates.failure and rec.result == 0.0:
                     if self.brain.reverse_sort:
@@ -1179,7 +1413,9 @@ class Controller:
                     self.save_state()
 
                 if self.delete_intermediate_ckpt:
-                    self.delete_checkpoint_files(cloud_expt_root, rec)
+                    self.delete_checkpoint_files(
+                        cloud_expt_root, rec, retain_resume_checkpoint=True
+                    )
                     # Remove the checkpoints from not best model
                     brain_dict = get_automl_brain_info(self.automl_context.id)
                     if brain_dict:
@@ -1197,7 +1433,10 @@ class Controller:
                                 f"AutoML ({self.automl_algorithm}): Non-resuming algorithm, "
                                 f"safe to delete non-best checkpoints"
                             )
-                        elif self.automl_algorithm in ("hyperband", "h", "bohb", "dehb", "hyperband_es", "hes"):
+                        elif self.automl_algorithm in (
+                            "hyperband", "h", "bohb", "asha", "dehb",
+                            "hyperband_es", "hes"
+                        ):
                             # Hyperband-based: Only delete when bracket changes AND all configs complete
                             # This ensures configs needed for next rung's resume are preserved
                             if self.old_bracket != brain_dict.get("bracket", "0"):
@@ -1339,7 +1578,7 @@ class Controller:
                     f"Final Status: {status}\n"
                     f"Final Result: {validation_map}\n"
                     f"Reason: Experiment completed with status={status}\n"
-                    f"Action: Calling on_cancel_automl_job to delete StatefulSet\n"
+                    f"Action: Fencing and deleting the child backend\n"
                     f"{'-' * 80}"
                 )
 
@@ -1347,7 +1586,13 @@ class Controller:
                     self.automl_context.id,
                     f"Cancelling completed job {rec.job_id} (experiment {rec.id})"
                 )
-                on_cancel_automl_job(rec.job_id)
+                child_quiescent = cancel_automl_child_job(rec.job_id) is True
+                if not child_quiescent:
+                    logger.warning(
+                        "AutoML child %s reached %s but backend quiescence is "
+                        "not yet confirmed; checkpoint cleanup will retry",
+                        rec.job_id, status,
+                    )
             if old_status != status:
                 rec.update_status(status)
                 self.save_state()
@@ -1357,9 +1602,15 @@ class Controller:
                         with open(container_log_file, "a", encoding='utf-8') as f:
                             f.write("\nEOF\n")
 
-            if rec.status in [JobStates.success, JobStates.failure] and self.delete_intermediate_ckpt:
+            if (
+                rec.status in [JobStates.success, JobStates.failure] and
+                self.delete_intermediate_ckpt and
+                child_quiescent
+            ):
                 # Retain the latest checkpoint and remove others in experiment folder
-                self.delete_checkpoint_files(cloud_expt_root, rec)
+                self.delete_checkpoint_files(
+                    cloud_expt_root, rec, retain_resume_checkpoint=True
+                )
 
         if self.automl_algorithm in ("hyperband", "h", "bohb", "dehb", "hyperband_es", "hes"):
             brain_dict = get_automl_brain_info(self.automl_context.id)
@@ -1656,14 +1907,20 @@ class Controller:
                     return -1
         return -1
 
-    def get_checkpoint_paths_matching_epoch_number(self, path, rec_id):
+    def get_checkpoint_paths_matching_epoch_number(
+        self, path, rec_id, epoch_number=None
+    ):
         """Get checkpoints from cloud_path and filter based on epoch number
 
         For networks with folder-based checkpoints (like cosmos-rl), this will find
         folders for different formats (.pth, .safetensors) separately.
         """
         checkpoint_files = get_file_list_from_cloud_storage(self.decrypted_workspace_metadata, path)
-        format_epoch_number = format_epoch(self.network, self.best_epoch_number[rec_id])
+        selected_epoch = (
+            self.best_epoch_number[rec_id]
+            if epoch_number is None else epoch_number
+        )
+        format_epoch_number = format_epoch(self.network, selected_epoch)
         if self._uses_folder_lookup():
             # For folder lookup, look for epoch-numbered folders (e.g., epoch_1/, epoch_2/)
             if self.network in MISSING_EPOCH_FORMAT_NETWORKS:
@@ -1779,7 +2036,13 @@ class Controller:
             if find_trained_safetensors:
                 self.ckpt_path[path]["safetensors"] = find_trained_safetensors[0]
 
-    def delete_checkpoint_files(self, path, rec, filter_by_format=False):
+    def delete_checkpoint_files(
+        self,
+        path,
+        rec,
+        filter_by_format=False,
+        retain_resume_checkpoint=False,
+    ):
         """Remove the extra checkpoints generated after the on_cancel_automl_job"""
         report_health_beat(
             self.automl_context.id,
@@ -1794,9 +2057,34 @@ class Controller:
         trained_files = filter_files(trained_files, regex_pattern)
         logger.info("Available checkpoints in delete_checkpoint_files function %s", trained_files)
         self.get_best_checkpoint_path(path, rec, filter_by_format=filter_by_format)
+        if (
+            retain_resume_checkpoint and
+            self.automl_algorithm in (
+                "hyperband", "h", "bohb", "asha", "dehb",
+                "hyperband_es", "hes", "pbt",
+            ) and
+            getattr(rec, "early_stop_epoch", None) is not None
+        ):
+            resume_paths = self.get_checkpoint_paths_matching_epoch_number(
+                path, rec.id, epoch_number=rec.early_stop_epoch
+            )
+            for format_name, candidates in zip(
+                ("tlt", "hdf5", "pth", "ckzip", "safetensors"),
+                resume_paths,
+            ):
+                if candidates:
+                    candidate = candidates[0]
+                    if candidate not in self.ckpt_path[path].values():
+                        self.ckpt_path[path][f"resume_{format_name}"] = candidate
+            logger.info(
+                "Retaining rung-boundary checkpoint at epoch %s for possible "
+                "promotion of recommendation %s",
+                rec.early_stop_epoch, rec.id,
+            )
         logger.info("self.ckpt_path in delete_checkpoint_files function %s", self.ckpt_path)
         logger.info("RETAIN_CHECKPOINTS_FOR_RESUME setting: %s", self.retain_checkpoints_for_resume)
 
+        deletion_accepted = True
         for files in trained_files:
             should_delete = True
 
@@ -1815,21 +2103,53 @@ class Controller:
                 logger.info("Removing item in delete_checkpoint_files function %s", files)
                 if self.cs_instance.is_file(files):
                     logger.info("Removing file in delete_checkpoint_files function %s", files)
-                    self.cs_instance.delete_file(files)
+                    if self.cs_instance.delete_file(files) is False:
+                        deletion_accepted = False
                     report_health_beat(
                         self.automl_context.id,
                         f"Deleting checkpoint file {files} for experiment {rec.id}"
                     )
                 elif self._uses_folder_lookup():
                     logger.info("Removing folder in delete_checkpoint_files function %s", files)
-                    self.cs_instance.delete_folder(files[1:])
+                    if self.cs_instance.delete_folder(files[1:]) is False:
+                        deletion_accepted = False
                     report_health_beat(
                         self.automl_context.id,
                         f"Deleting checkpoint file {files} for experiment {rec.id}"
                     )
 
+        # Storage APIs can acknowledge a delete while leaving a prefix behind.
+        # Re-list and require every remaining checkpoint to belong to the one
+        # protected best checkpoint. A stale remote listing simply leaves the
+        # durable cleanup phase pending for retry.
+        remaining = filter_files(
+            get_file_list_from_cloud_storage(
+                self.decrypted_workspace_metadata, path
+            ),
+            regex_pattern,
+        )
+        protected = tuple(self.ckpt_path[path].values())
+        if self._uses_folder_lookup():
+            unprotected = [
+                item for item in remaining
+                if not any(
+                    item == checkpoint or item.startswith(checkpoint + "/")
+                    for checkpoint in protected
+                )
+            ]
+        else:
+            unprotected = [item for item in remaining if item not in protected]
+        if unprotected:
+            logger.warning(
+                "Checkpoint cleanup for experiment %s is not yet visible; "
+                "remaining unprotected artifacts: %s",
+                rec.id, unprotected,
+            )
+        return deletion_accepted and not unprotected
+
     def delete_not_best_model_checkpoints(self, path, rec, flag):
         """Remove the checkpoints which don't correspond to the best result"""
+        self._last_checkpoint_delete_verified = True
         try:
             valid_recs = [r for r in self.recommendations
                           if r.status in (JobStates.success, JobStates.failure)]
@@ -1855,10 +2175,70 @@ class Controller:
             regex_pattern = r'.*(?:lightning_logs|events).*$|.*\.(tlt|hdf5|pth|ckzip|safetensors|resume)$'
             trained_files = filter_files(trained_files, regex_pattern)
             logger.info("Available checkpoints in delete_not_best_model_checkpoints function %s", trained_files)
-            for files in trained_files:
-                if self.cs_instance.is_file(files):
-                    logger.info("Removing files in delete_not_best_model_checkpoints function %s", files)
-                    self.cs_instance.delete_file(files)
+            if self._uses_folder_lookup():
+                # Folder checkpoints contain marker/config files without a recognized
+                # extension (for example Cosmos .rank_*_complete and cosmos_config).
+                # Delete each checkpoint leaf recursively so those sidecars do not remain.
+                result_root = os.path.normpath(path).lstrip("/")
+                checkpoint_folders = []
+                checkpoint_folder_keys = []
+                flat_checkpoint_files = []
+                for files in sorted(
+                    trained_files, key=lambda item: os.path.dirname(item).count("/")
+                ):
+                    folder = os.path.dirname(files)
+                    folder_key = os.path.normpath(folder).lstrip("/")
+                    if folder_key == result_root:
+                        # Never recursively delete the experiment root merely because a
+                        # folder-based network wrote a checkpoint directly into it.
+                        flat_checkpoint_files.append(files)
+                    elif not folder_key.startswith(result_root + "/"):
+                        logger.warning(
+                            "Skipping checkpoint path outside experiment root %s: %s",
+                            path, files
+                        )
+                    elif not any(
+                        folder_key == existing or folder_key.startswith(existing + "/")
+                        for existing in checkpoint_folder_keys
+                    ):
+                        checkpoint_folders.append(folder)
+                        checkpoint_folder_keys.append(folder_key)
+
+                for folder in checkpoint_folders:
+                    logger.info(
+                        "Removing folder in delete_not_best_model_checkpoints function %s",
+                        folder
+                    )
+                    if self.cs_instance.delete_folder(folder) is False:
+                        self._last_checkpoint_delete_verified = False
+                for files in flat_checkpoint_files:
+                    if self.cs_instance.is_file(files):
+                        logger.info(
+                            "Removing file in delete_not_best_model_checkpoints function %s",
+                            files
+                        )
+                        if self.cs_instance.delete_file(files) is False:
+                            self._last_checkpoint_delete_verified = False
+            else:
+                for files in trained_files:
+                    if self.cs_instance.is_file(files):
+                        logger.info("Removing files in delete_not_best_model_checkpoints function %s", files)
+                        if self.cs_instance.delete_file(files) is False:
+                            self._last_checkpoint_delete_verified = False
+
+            remaining = filter_files(
+                get_file_list_from_cloud_storage(
+                    self.decrypted_workspace_metadata, path
+                ),
+                regex_pattern,
+            )
+            if remaining:
+                self._last_checkpoint_delete_verified = False
+                logger.warning(
+                    "Checkpoint deletion for recommendation %s is not yet "
+                    "visible; retaining cleanup intent for: %s",
+                    rec.id, remaining,
+                )
         else:
             flag = True
         return flag

--- a/nvidia_tao_core/microservices/handlers/actions.py
+++ b/nvidia_tao_core/microservices/handlers/actions.py
@@ -47,7 +47,11 @@ from nvidia_tao_core.microservices.utils.stateless_handler_utils import (
     get_automl_brain_info,
     get_automl_best_rec_info,
     get_automl_controller_info,
+    claim_automl_child_launch,
+    claim_automl_child_relaunch,
+    get_automl_child_lifecycle,
     save_automl_controller_info,
+    set_automl_child_launch_state,
     get_dnn_status,
     update_job_metadata,
     update_job_status,
@@ -1247,6 +1251,37 @@ class AutoMLPipeline(ActionPipeline):
                 break
         return rec_number
 
+    def _cancellation_requested(self):
+        """Check the durable parent/child cancellation fences."""
+        lifecycle = get_automl_child_lifecycle(self.job_name)
+        if lifecycle["cancel_requested"]:
+            return True
+        parent_metadata = get_handler_job_metadata(self.automl_brain_job_id) or {}
+        if str(parent_metadata.get("status", "")).lower() in (
+            "canceled", "canceling", "paused", "pausing"
+        ):
+            return True
+        recommendations = get_automl_controller_info(self.automl_brain_job_id) or []
+        if self.rec_number is None or self.rec_number >= len(recommendations):
+            return True
+        return str(recommendations[self.rec_number].get("status", "")).lower() in (
+            "canceled", "canceling"
+        )
+
+    def _finish_canceled_launch(self, backend_may_exist=False):
+        """Abort a fenced launch and persist quiescence only after confirmation."""
+        if not backend_may_exist:
+            return set_automl_child_launch_state(self.job_name, "quiescent")
+        deleted = ExecutionHandler.delete_with_handler(
+            self.job_name, workspace_metadata=self.workspace_metadata
+        )
+        if deleted is True:
+            return set_automl_child_launch_state(self.job_name, "quiescent")
+        set_automl_child_launch_state(
+            self.job_name, "cancel_failed", "backend quiescence was not confirmed"
+        )
+        return False
+
     def monitor_job(self, nv_job_metadata=None):
         """Monitors the job status and updates job metadata"""
         if not self.spec:
@@ -1315,27 +1350,46 @@ class AutoMLPipeline(ActionPipeline):
                 break
             if k8s_status == "Error":
                 self.detailed_print(f"Relaunching job {self.job_name}")
+                if not claim_automl_child_relaunch(self.job_name):
+                    if self._cancellation_requested():
+                        self._finish_canceled_launch(backend_may_exist=True)
+                    break
                 wait_for_job_completion(self.job_name)
                 nv_job_metadata = {}
                 self.generate_nv_job_metadata(nv_job_metadata, workspace_metadata=self.workspace_metadata)
-                if BACKEND in (Backend.LOCAL_K8S, Backend.LOCAL_DOCKER):
-                    self.create_microservice_action_job(self.automl_brain_job_id, nv_job_metadata=nv_job_metadata)
-                else:
-                    ExecutionHandler.create_job_with_handler(
-                        org_name=self.job_context.org_name,
-                        job_name=self.job_name,
-                        image=self.image,
-                        command=run_command,
-                        workspace_metadata=self.workspace_metadata,
-                        num_gpu=self.num_gpu,
-                        num_nodes=self.num_nodes,
-                        accelerator=self.accelerator,
-                        docker_env_vars=self.job_env_variables,
-                        nv_job_metadata=nv_job_metadata,
-                        automl_brain=False,
-                        automl_exp_job=True,
-                        backend_details=self.job_context.backend_details
+                if self._cancellation_requested():
+                    self._finish_canceled_launch(backend_may_exist=True)
+                    break
+                try:
+                    if BACKEND in (Backend.LOCAL_K8S, Backend.LOCAL_DOCKER):
+                        self.create_microservice_action_job(
+                            self.automl_brain_job_id, nv_job_metadata=nv_job_metadata
+                        )
+                    else:
+                        ExecutionHandler.create_job_with_handler(
+                            org_name=self.job_context.org_name,
+                            job_name=self.job_name,
+                            image=self.image,
+                            command=run_command,
+                            workspace_metadata=self.workspace_metadata,
+                            num_gpu=self.num_gpu,
+                            num_nodes=self.num_nodes,
+                            accelerator=self.accelerator,
+                            docker_env_vars=self.job_env_variables,
+                            nv_job_metadata=nv_job_metadata,
+                            automl_brain=False,
+                            automl_exp_job=True,
+                            backend_details=self.job_context.backend_details
+                        )
+                except Exception as err:
+                    set_automl_child_launch_state(
+                        self.job_name, "uncertain", error=err
                     )
+                    raise
+                if self._cancellation_requested():
+                    self._finish_canceled_launch(backend_may_exist=True)
+                    break
+                set_automl_child_launch_state(self.job_name, "running")
             k8s_status = ExecutionHandler.get_job_status_with_handler(
                 job_name=self.job_name,
                 workspace_metadata=self.workspace_metadata,
@@ -1357,7 +1411,27 @@ class AutoMLPipeline(ActionPipeline):
 
     def run(self):
         """Calls necessary setup functions and calls job creation"""
+        launch_claimed = False
+        backend_create_started = False
         try:
+            launch_claimed = claim_automl_child_launch(self.job_name)
+            if not launch_claimed:
+                lifecycle = get_automl_child_lifecycle(self.job_name)
+                if lifecycle["cancel_requested"] and lifecycle["launch_state"] not in (
+                    "submitting", "running", "uncertain", "cancel_failed"
+                ):
+                    set_automl_child_launch_state(self.job_name, "quiescent")
+                logger.info(
+                    "AutoML child %s did not acquire launch claim; state=%s cancel_requested=%s",
+                    self.job_name,
+                    lifecycle["launch_state"],
+                    lifecycle["cancel_requested"],
+                )
+                return False
+            if self._cancellation_requested():
+                self._finish_canceled_launch(backend_may_exist=False)
+                return False
+
             recommended_values = self.recs_dict[self.rec_number].get("specs", {})
             self.cs_instance, _ = create_cs_instance(self.workspace_metadata)
             self.add_ptm_dependency(recommended_values)
@@ -1385,6 +1459,11 @@ class AutoMLPipeline(ActionPipeline):
             nv_job_metadata = {}
             self.generate_nv_job_metadata(nv_job_metadata, workspace_metadata=self.workspace_metadata)
 
+            if self._cancellation_requested():
+                self._finish_canceled_launch(backend_may_exist=False)
+                return False
+
+            backend_create_started = True
             if BACKEND in (Backend.LOCAL_K8S, Backend.LOCAL_DOCKER):
                 self.create_microservice_action_job(self.automl_brain_job_id, nv_job_metadata=nv_job_metadata)
             else:
@@ -1403,6 +1482,14 @@ class AutoMLPipeline(ActionPipeline):
                     automl_exp_job=False,
                     backend_details=self.job_context.backend_details
                 )
+
+            if self._cancellation_requested():
+                self._finish_canceled_launch(backend_may_exist=True)
+                return False
+            if not set_automl_child_launch_state(self.job_name, "running"):
+                raise RuntimeError(
+                    f"Unable to persist running launch state for AutoML child {self.job_name}"
+                )
             self.detailed_print(
                 f"AutoML recommendation with experiment id {self.rec_number} "
                 f"and job id {self.job_name} submitted"
@@ -1412,11 +1499,22 @@ class AutoMLPipeline(ActionPipeline):
             # This is the AutoML equivalent of the Pending → Started write
             # that normal jobs do in tao.jobs. It tells _reclaim_stale_gpus
             # that the container/pod now exists and can be checked.
-            if self.recs_dict and self.rec_number is not None:
-                prev_status = self.recs_dict[self.rec_number].get("status", "")
+            latest_recommendations = get_automl_controller_info(
+                self.automl_brain_job_id
+            ) or []
+            if (
+                latest_recommendations and
+                self.rec_number is not None and
+                self.rec_number < len(latest_recommendations) and
+                not self._cancellation_requested()
+            ):
+                prev_status = latest_recommendations[self.rec_number].get("status", "")
                 if prev_status in ("pending", ""):
-                    self.recs_dict[self.rec_number]["status"] = "started"
-                    save_automl_controller_info(self.automl_brain_job_id, self.recs_dict)
+                    latest_recommendations[self.rec_number]["status"] = "started"
+                    save_automl_controller_info(
+                        self.automl_brain_job_id, latest_recommendations
+                    )
+                    self.recs_dict = latest_recommendations
                     logger.info(
                         f"[LIFECYCLE] AutoML rec {self.rec_number} (job {self.job_name}): "
                         f"{prev_status or '(none)'} → started (container created)"
@@ -1492,6 +1590,18 @@ class AutoMLPipeline(ActionPipeline):
             return True
 
         except Exception as e:
+            lifecycle = get_automl_child_lifecycle(self.job_name)
+            if launch_claimed and lifecycle["launch_state"] == "submitting":
+                set_automl_child_launch_state(
+                    self.job_name,
+                    "uncertain" if backend_create_started else "quiescent",
+                    error=e if backend_create_started else "",
+                )
+            if self._cancellation_requested():
+                self._finish_canceled_launch(
+                    backend_may_exist=backend_create_started
+                )
+                return False
             self.detailed_print(
                 f"AutoMLpipeline for network {self.network} failed due to "
                 f"exception {traceback.format_exc()}"
@@ -1515,13 +1625,36 @@ class AutoMLPipeline(ActionPipeline):
             )
             self.detailed_print(self.job_name)
 
-            self.recs_dict[self.rec_number]["status"] = "failure"
-            save_automl_controller_info(self.automl_brain_job_id, self.recs_dict)
+            latest_recommendations = get_automl_controller_info(
+                self.automl_brain_job_id
+            ) or []
+            if self.rec_number is not None and self.rec_number < len(latest_recommendations):
+                latest_recommendations[self.rec_number]["status"] = "failure"
+                save_automl_controller_info(
+                    self.automl_brain_job_id, latest_recommendations
+                )
+                self.recs_dict = latest_recommendations
             update_automl_details_metadata(self.automl_brain_job_id, self.handler_id, self.handler_kind)
 
             update_job_status(self.handler_id, self.job_context.id, status="Error", kind=self.handler_kind)
-            ExecutionHandler.delete_with_handler(self.job_context.id, workspace_metadata=self.workspace_metadata)
+            deletion_confirmed = ExecutionHandler.delete_with_handler(
+                self.job_context.id, workspace_metadata=self.workspace_metadata
+            )
+            set_automl_child_launch_state(
+                self.job_name,
+                "quiescent" if deletion_confirmed is True else "uncertain",
+                "" if deletion_confirmed is True else "backend quiescence was not confirmed",
+            )
             return False
+        finally:
+            if launch_claimed:
+                lifecycle = get_automl_child_lifecycle(self.job_name)
+                if lifecycle["launch_state"] == "submitting":
+                    set_automl_child_launch_state(
+                        self.job_name,
+                        "uncertain" if backend_create_started else "quiescent",
+                        "launch exited without a terminal handshake state",
+                    )
 
 
 # Each Element can be called with a job_context and returns an ActionPipeline (or its derivative) object

--- a/nvidia_tao_core/microservices/handlers/automl_handler.py
+++ b/nvidia_tao_core/microservices/handlers/automl_handler.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 import sysconfig
 import logging
+import time
 
 from nvidia_tao_core.microservices.utils.automl_utils import update_automl_details_metadata
 from nvidia_tao_core.microservices.utils.stateless_handler_utils import (
@@ -21,14 +22,18 @@ from nvidia_tao_core.microservices.utils.stateless_handler_utils import (
     serialize_object,
     write_job_metadata,
     get_handler_job_metadata,
+    get_automl_child_job_ids,
+    request_automl_child_cancellation,
     update_handler_with_jobs_info,
-    get_automl_controller_info
+    get_automl_controller_info,
+    set_automl_checkpoint_cleanup_state,
 )
 from nvidia_tao_core.microservices.enum_constants import Backend
 from nvidia_tao_core.microservices.utils.handler_utils import Code, decrypt_handler_metadata
 from .docker_images import DOCKER_IMAGE_MAPPER
 from nvidia_tao_core.microservices.handlers.execution_handlers.execution_handler import ExecutionHandler
 from nvidia_tao_core.microservices.utils.log_monitor_service import start_monitoring_job, stop_monitoring_job
+from nvidia_tao_core.microservices.utils.automl_job_utils import cancel_automl_child_job
 
 # TODO Make sure the image name is current docker tag of the API
 image = DOCKER_IMAGE_MAPPER["API"]
@@ -276,7 +281,7 @@ class AutoMLHandler:
             logger.debug(f"[AUTOML] Skipping log monitoring for backend {backend}")
 
     @staticmethod
-    def stop(user_id, org_name, experiment_id, job_id):
+    def stop(user_id, org_name, experiment_id, job_id, cleanup_checkpoints=True):
         """Stops a running AutoML job and cancels any active recommendations.
 
         Args:
@@ -294,124 +299,91 @@ class AutoMLHandler:
         )
 
         try:
-            logger.debug(f"[AUTOML-STOP] Deleting AutoML brain K8s job: job_id={job_id}")
+            recommendations = get_automl_controller_info(job_id) or []
+            child_job_ids = {
+                recommendation.get("job_id")
+                for recommendation in recommendations
+                if recommendation.get("job_id")
+            }
+            child_job_ids.update(get_automl_child_job_ids(job_id))
 
-            # Stop log monitoring for brain job
-            logger.debug(f"[AUTOML] Stopping brain job {job_id}, checking if should stop log monitoring")
+            for recommendation in recommendations:
+                status = str(recommendation.get("status", "")).lower()
+                if status not in ("done", "success", "failure", "error", "canceled"):
+                    recommendation["status"] = "canceling"
+            if recommendations:
+                save_automl_controller_info(job_id, recommendations)
+                update_automl_details_metadata(job_id, experiment_id, "experiments")
+
+            cancellation_intents_persisted = all(
+                request_automl_child_cancellation(child_job_id)
+                for child_job_id in sorted(child_job_ids)
+            )
+            if not cancellation_intents_persisted:
+                return Code(409, [], "child cancellation intent could not be persisted")
+
+            if cleanup_checkpoints and not set_automl_checkpoint_cleanup_state(
+                job_id, "pending"
+            ):
+                return Code(409, [], "checkpoint cleanup intent could not be persisted")
+
+            timeout_seconds = int(os.getenv("AUTOML_CANCEL_TIMEOUT_SECONDS", "180"))
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                child_results = [
+                    cancel_automl_child_job(child_job_id) is True
+                    for child_job_id in sorted(child_job_ids)
+                ]
+                children_quiescent = all(child_results)
+                cleanup_complete = not cleanup_checkpoints
+                if cleanup_checkpoints:
+                    metadata = get_handler_job_metadata(job_id) or {}
+                    cleanup_complete = (
+                        metadata.get("checkpoint_cleanup_pending") is False and
+                        metadata.get("checkpoint_cleanup_status") in ("complete", "skipped")
+                    )
+
+                if children_quiescent and cleanup_complete:
+                    break
+                if time.monotonic() >= deadline:
+                    logger.error(
+                        "AutoML cancellation barrier timed out for %s "
+                        "(children_quiescent=%s, cleanup_complete=%s)",
+                        job_id, children_quiescent, cleanup_complete,
+                    )
+                    return Code(
+                        409,
+                        {"message": f"job {job_id} remains Canceling"},
+                        "child quiescence or checkpoint cleanup is still pending",
+                    )
+                time.sleep(1)
+
+            latest_recommendations = get_automl_controller_info(job_id) or recommendations
+            for recommendation in latest_recommendations:
+                status = str(recommendation.get("status", "")).lower()
+                if status not in ("done", "success", "failure", "error", "canceled"):
+                    recommendation["status"] = "canceled"
+            if latest_recommendations:
+                save_automl_controller_info(job_id, latest_recommendations)
+                update_automl_details_metadata(job_id, experiment_id, "experiments")
+
+            # The brain remains alive until it has acknowledged durable cleanup.
+            if ExecutionHandler.delete_job_with_handler(job_id) is not True:
+                return Code(409, [], "AutoML brain termination was not accepted")
+            handler = ExecutionHandler.create_handler(backend=BACKEND, job_id=job_id)
+            if not handler or not handler.wait_for_job_termination(
+                job_id, timeout_seconds=120
+            ):
+                return Code(409, [], "AutoML brain termination was not confirmed")
+
             if BACKEND in (Backend.LOCAL_K8S, Backend.LOCAL_DOCKER):
                 try:
-                    logger.info(f"[AUTOML] Stopping log monitoring for AutoML brain job {job_id}")
                     stop_monitoring_job(job_id)
-                    logger.info(f"[AUTOML] Successfully stopped log monitoring for AutoML brain job {job_id}")
-                except Exception as e:
+                except Exception as err:
                     logger.warning(
-                        f"[AUTOML] Failed to stop log monitoring for AutoML brain job {job_id}: "
-                        f"{type(e).__name__}: {e}"
+                        "Failed to stop log monitoring for AutoML brain %s: %s",
+                        job_id, err,
                     )
-
-            ExecutionHandler.delete_job_with_handler(job_id)
-            logger.debug(f"[AUTOML-STOP] Brain K8s job deleted, waiting for pod termination: job_id={job_id}")
-
-            # Wait for actual K8s Job/Pod to terminate (synchronous)
-            handler = ExecutionHandler.create_handler(backend=BACKEND, job_id=job_id)
-            job_terminated = handler.wait_for_job_termination(job_id, timeout_seconds=120) if handler else False
-            if not job_terminated:
-                logger.warning(f"[AUTOML-STOP] Timeout waiting for brain termination: job_id={job_id}")
-            else:
-                logger.debug(f"[AUTOML-STOP] Brain termination confirmed: job_id={job_id}")
-
-            recommendations = get_automl_controller_info(job_id)
-            logger.debug(
-                f"[AUTOML-STOP] Retrieved recommendations: job_id={job_id}, "
-                f"num_recommendations={len(recommendations) if recommendations else 0}"
-            )
-            for idx, recommendation in enumerate(recommendations):
-                recommendation_job_id = recommendation.get("job_id")
-                rec_status = recommendation.get("status")
-                logger.debug(
-                    f"[AUTOML-STOP] Processing recommendation {idx}: "
-                    f"rec_job_id={recommendation_job_id}, status={rec_status}"
-                )
-
-                # Update status to canceling for all non-terminal states
-                if rec_status not in ("done", "success", "failure", "error", "canceled", "canceling"):
-                    logger.debug(
-                        f"[AUTOML-STOP] Updating recommendation status to canceling: "
-                        f"rec_job_id={recommendation_job_id}, old_status={rec_status}"
-                    )
-                    recommendation["status"] = "canceling"
-                    save_automl_controller_info(job_id, recommendations)
-                    logger.debug(f"[AUTOML-STOP] Saved controller info to MongoDB: job_id={job_id}")
-                    # Verify the save worked
-                    verification = get_automl_controller_info(job_id)
-                    verified_status = (
-                        verification[idx]["status"]
-                        if verification and idx < len(verification) else "NOT_FOUND"
-                    )
-                    logger.debug(
-                        f"[AUTOML-STOP] Verified status in MongoDB: "
-                        f"rec_job_id={recommendation_job_id}, status={verified_status}"
-                    )
-                    update_automl_details_metadata(job_id, experiment_id, "experiments")
-
-                if recommendation_job_id:
-                    logger.debug(
-                        f"[AUTOML-STOP] Deleting recommendation statefulset: "
-                        f"rec_job_id={recommendation_job_id}"
-                    )
-                    ExecutionHandler.delete_with_handler(recommendation_job_id)
-                    logger.debug(
-                        f"[AUTOML-STOP] Waiting for recommendation pod termination: "
-                        f"rec_job_id={recommendation_job_id}"
-                    )
-
-                    rec_handler = ExecutionHandler.create_handler(
-                        backend=BACKEND, job_id=recommendation_job_id
-                    )
-                    job_terminated = (
-                        rec_handler.wait_for_termination(recommendation_job_id, timeout_seconds=120)
-                        if rec_handler else False
-                    )
-                    if not job_terminated:
-                        logger.warning(
-                            f"[AUTOML-STOP] Timeout waiting for recommendation termination: "
-                            f"rec_job_id={recommendation_job_id}"
-                        )
-                    else:
-                        logger.debug(
-                            f"[AUTOML-STOP] Recommendation termination confirmed: "
-                            f"rec_job_id={recommendation_job_id}"
-                        )
-
-                # Update ALL non-terminal recommendations to canceled (check current status after potential updates)
-                current_status = recommendation.get("status")
-                if current_status not in ("done", "success", "failure", "error", "canceled"):
-                    logger.debug(
-                        f"[AUTOML-STOP] Updating recommendation status to canceled: "
-                        f"rec_job_id={recommendation_job_id}, old_status={current_status}"
-                    )
-                    recommendation["status"] = "canceled"
-                    save_automl_controller_info(job_id, recommendations)
-                    logger.debug(f"[AUTOML-STOP] Saved controller info to MongoDB: job_id={job_id}")
-                    # Verify the save worked
-                    verification = get_automl_controller_info(job_id)
-                    verified_status = (
-                        verification[idx]["status"]
-                        if verification and idx < len(verification) else "NOT_FOUND"
-                    )
-                    logger.debug(
-                        f"[AUTOML-STOP] Verified final status in MongoDB: "
-                        f"rec_job_id={recommendation_job_id}, status={verified_status}"
-                    )
-                    update_automl_details_metadata(job_id, experiment_id, "experiments")
-                else:
-                    logger.debug(
-                        f"[AUTOML-STOP] Skipping status update for terminal state: "
-                        f"rec_job_id={recommendation_job_id}, status={current_status}"
-                    )
-            logger.debug(
-                f"[AUTOML-STOP] AutoML stop operation completed successfully: job_id={job_id}"
-            )
         except Exception as e:
             logger.error(f"[AUTOML-STOP] Exception thrown in AutoMLHandler stop: job_id={job_id}, error={str(e)}")
             logger.error(f"[AUTOML-STOP] Traceback: {traceback.format_exc()}")

--- a/nvidia_tao_core/microservices/handlers/execution_handlers/docker_handler.py
+++ b/nvidia_tao_core/microservices/handlers/execution_handlers/docker_handler.py
@@ -7,6 +7,7 @@
 
 import logging
 import os
+import re
 import time
 import requests
 import subprocess
@@ -39,6 +40,115 @@ logger = logging.getLogger(__name__)
 DOCKER_NETWORK = os.getenv("DOCKER_NETWORK", "tao_default")
 DOCKER_USERNAME = os.getenv("DOCKER_USERNAME", "$oauthtoken")
 docker_client = docker.from_env() if os.getenv("DOCKER_HOST") else None
+
+_DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+_CONTAINER_USER_ENV = "TAO_DOCKER_CONTAINER_USER"
+_CONTAINER_GROUPS_ENV = "TAO_DOCKER_GROUP_ADD"
+
+
+def _read_only_volume_mode(mode):
+    """Return whether a Docker volume mode explicitly makes the mount read-only."""
+    return "ro" in {
+        token.strip().lower() for token in str(mode or "rw").split(",")
+    }
+
+
+def _writable_bind_mounts(volumes):
+    """Normalize writable volume specs to ``(source, target, mode)`` tuples.
+
+    Docker accepts both ``{"/host": {"bind": "/container", "mode": "rw"}}``
+    and CLI-like ``["/host:/container:rw"]`` forms. The Docker socket is a
+    control-plane mount, not a training-output path, and must not force a
+    workload user override.
+    """
+    normalized = []
+    if not volumes:
+        return normalized
+
+    if isinstance(volumes, dict):
+        entries = []
+        for source, details in volumes.items():
+            if isinstance(details, dict):
+                target = details.get("bind", "")
+                if "ro" in details and "mode" in details:
+                    raise ValueError(
+                        f'Docker volume cannot contain both "ro" and "mode": {details!r}'
+                    )
+                if "ro" in details:
+                    mode = "ro" if details["ro"] else "rw"
+                else:
+                    mode = details.get("mode", "rw")
+                propagation = details.get("propagation")
+                if propagation:
+                    mode = f"{mode},{propagation}" if mode else str(propagation)
+            else:
+                target = details
+                mode = "rw"
+            entries.append((source, target, mode))
+    else:
+        entries = []
+        for volume in volumes:
+            parts = str(volume).split(":")
+            if len(parts) == 1:
+                # A single container path asks Docker for an anonymous volume;
+                # it is not a host bind and carries no host-ownership contract.
+                continue
+            source, target = parts[0], parts[1]
+            mode = parts[2] if len(parts) > 2 else "rw"
+            entries.append((source, target, mode))
+
+    seen = set()
+    for source, target, mode in entries:
+        source = str(source or "").strip()
+        target = str(target or "").strip()
+        # Read-only and control-plane mounts do not create host output. Leave
+        # their full validation to Docker so this ownership guard does not
+        # reject otherwise-supported legacy specifications.
+        if _read_only_volume_mode(mode):
+            continue
+        if _DOCKER_SOCKET_PATH in (source, target):
+            continue
+        if not source or not target.startswith("/") or target == "/":
+            raise ValueError(
+                f"Docker writable bind requires a source and non-root absolute target: "
+                f"{source!r}:{target!r}"
+            )
+        mount = (source, target, str(mode or "rw"))
+        if mount not in seen:
+            normalized.append(mount)
+            seen.add(mount)
+    return normalized
+
+
+def _configured_container_identity():
+    """Return the explicitly configured host submitting identity and groups.
+
+    TAO Core often talks to the host daemon from inside a service container, so
+    its own ``os.getuid()`` is not evidence of the host user's identity. Never
+    infer the user from a bind directory owner either: shared roots are commonly
+    owned by ``root:<group>`` or by another group member.
+    """
+    raw_user = os.getenv(_CONTAINER_USER_ENV, "").strip()
+    match = re.fullmatch(r"(\d+):(\d+)", raw_user)
+    if not match or int(match.group(1)) == 0:
+        raise RuntimeError(
+            f"Writable Docker output binds require {_CONTAINER_USER_ENV}=UID:GID "
+            "for the verified non-root host submitting user"
+        )
+    uid, gid = match.groups()
+
+    raw_groups = os.getenv(_CONTAINER_GROUPS_ENV, "").strip()
+    groups = []
+    if raw_groups:
+        for token in re.split(r"[\s,]+", raw_groups):
+            if not token or not token.isdigit():
+                raise RuntimeError(
+                    f"{_CONTAINER_GROUPS_ENV} must be a comma-separated list of "
+                    "numeric supplementary GIDs"
+                )
+            if token != gid and token not in groups:
+                groups.append(token)
+    return f"{uid}:{gid}", groups
 
 
 def is_tegra_platform():
@@ -192,6 +302,164 @@ class DockerHandler(ExecutionHandler):
                 logger.error(f"Error logging in to NGC registry {self._docker_registry}: {e}")
         return None
 
+    def _preflight_writable_bind(
+        self, source, mode, container_user, group_add, prepare_home=False
+    ):
+        """Prove the configured identity can create and delete through one bind.
+
+        The probe runs through the same Docker daemon as the workload. This is
+        required when TAO Core itself is containerized or uses a remote daemon,
+        where client-side filesystem ownership and ``os.access`` checks describe
+        the wrong host.
+        """
+        directory_commands = [
+            "umask 077",
+            "probe=/ownership-probe/.tao-write-delete-probe-$$",
+            # mkdir is an atomic no-follow create. It proves create/delete
+            # permission without following a pre-planted file symlink.
+            'mkdir "$probe"',
+            'rmdir "$probe"',
+        ]
+        if prepare_home:
+            directory_commands.extend([
+                "runtime=/ownership-probe/.tao-runtime",
+                'home="$runtime/home"',
+                'cache="$home/.cache"',
+                "for path in \"$runtime\" \"$home\" \"$cache\" "
+                "\"$cache/huggingface\" \"$cache/torch\" \"$cache/triton\" "
+                "\"$cache/torchinductor\" \"$cache/matplotlib\" "
+                "\"$home/.config\" \"$home/.local\"; do "
+                "test ! -L \"$path\"; done",
+                "mkdir -p \"$cache/huggingface\" \"$cache/torch\" "
+                "\"$cache/triton\" \"$cache/torchinductor\" "
+                "\"$cache/matplotlib\" \"$home/.config\" \"$home/.local\"",
+                "for path in \"$runtime\" \"$home\" \"$cache\" "
+                "\"$cache/huggingface\" \"$cache/torch\" \"$cache/triton\" "
+                "\"$cache/torchinductor\" \"$cache/matplotlib\" "
+                "\"$home/.config\" \"$home/.local\"; do "
+                "test -d \"$path\"; test ! -L \"$path\"; chmod 700 \"$path\"; done",
+            ])
+        file_commands = ["exit 1"] if prepare_home else ["test -w /ownership-probe"]
+        script = "\n".join([
+            "set -eu",
+            "if [ -d /ownership-probe ]; then",
+            *(f"  {command}" for command in directory_commands),
+            "elif [ -f /ownership-probe ]; then",
+            *(f"  {command}" for command in file_commands),
+            "else",
+            "  exit 1",
+            "fi",
+        ])
+        try:
+            self._docker_client.containers.run(
+                image=self._docker_image,
+                entrypoint="/bin/sh",
+                command=["-c", script],
+                user=container_user,
+                group_add=group_add or None,
+                # Preserve SELinux relabel and bind-propagation options so the
+                # proof exercises the same host access path as the workload.
+                volumes={source: {"bind": "/ownership-probe", "mode": mode}},
+                working_dir="/",
+                network_disabled=True,
+                remove=True,
+            )
+        except Exception as exc:
+            raise PermissionError(
+                f"Configured Docker identity {container_user} could not create and "
+                f"delete files through writable bind {source!r}; repair access or "
+                f"correct {_CONTAINER_USER_ENV}/{_CONTAINER_GROUPS_ENV} before launch"
+            ) from exc
+
+    def _assert_host_identity_mapping_supported(self):
+        """Reject daemons whose user namespace obscures host UID/GID ownership."""
+        try:
+            daemon_info = self._docker_client.info()
+        except Exception as exc:
+            raise RuntimeError(
+                "Could not verify Docker daemon identity-mapping mode; refusing "
+                "a writable /results launch"
+            ) from exc
+        if not isinstance(daemon_info, dict):
+            raise RuntimeError(
+                "Docker daemon returned unverifiable identity-mapping metadata; "
+                "refusing a writable /results launch"
+            )
+
+        security_options = {
+            str(option).strip().lower()
+            for option in daemon_info.get("SecurityOptions", []) or []
+        }
+        remapped = bool(daemon_info.get("Rootless")) or any(
+            option == "name=rootless" or
+            option.startswith("name=userns") or
+            option.startswith("userns")
+            for option in security_options
+        )
+        if remapped:
+            raise RuntimeError(
+                "Writable /results ownership cannot be guaranteed with a "
+                "rootless or userns-remapped Docker daemon"
+            )
+
+    def _prepare_writable_bind_runtime(
+        self,
+        volumes,
+        writable_mounts=None,
+        configured_identity=None,
+        identity_mapping_verified=False,
+    ):
+        """Validate writable binds and return Docker user/environment overrides."""
+        if writable_mounts is None:
+            writable_mounts = _writable_bind_mounts(volumes)
+        results_mount = next(
+            (
+                mount for mount in writable_mounts
+                if mount[1].rstrip("/") == "/results"
+            ),
+            None,
+        )
+        # This ownership contract is deliberately scoped to TAO output binds.
+        # Anonymous volumes and unrelated writable file/config mounts retain
+        # their existing Docker semantics and never become a runtime HOME.
+        if results_mount is None:
+            return None
+
+        if not identity_mapping_verified:
+            self._assert_host_identity_mapping_supported()
+        container_user, group_add = configured_identity or _configured_container_identity()
+        home_source, home_target, _ = results_mount
+        prepared_sources = set()
+        for source, _target, mode in writable_mounts:
+            if source in prepared_sources:
+                continue
+            self._preflight_writable_bind(
+                source,
+                mode,
+                container_user,
+                group_add,
+                prepare_home=source == home_source,
+            )
+            prepared_sources.add(source)
+
+        home = f"{home_target.rstrip('/')}/.tao-runtime/home"
+        uid = container_user.split(":", 1)[0]
+        environment = {
+            "HOME": home,
+            # Numeric identities need not have a matching /etc/passwd entry in
+            # the image. Numeric USER/LOGNAME values accurately describe that
+            # situation while HOME keeps libraries away from /root.
+            "USER": uid,
+            "LOGNAME": uid,
+            "XDG_CACHE_HOME": f"{home}/.cache",
+            "HF_HOME": f"{home}/.cache/huggingface",
+            "TORCH_HOME": f"{home}/.cache/torch",
+            "TRITON_CACHE_DIR": f"{home}/.cache/triton",
+            "TORCHINDUCTOR_CACHE_DIR": f"{home}/.cache/torchinductor",
+            "MPLCONFIGDIR": f"{home}/.cache/matplotlib",
+        }
+        return container_user, group_add, environment
+
     @staticmethod
     def get_handler_for_container(container_name=None):
         """Initialize a docker handler from a container."""
@@ -205,6 +473,20 @@ class DockerHandler(ExecutionHandler):
             image_ref = container.image.tags[0] if container.image.tags else container.image.id
             logger.info(f"Found container image {image_ref} for {container_name}")
             return DockerHandler(image_ref, container=container)
+        except docker.errors.NotFound:
+            # Preserve the distinction between a definitive 404 and a daemon/
+            # transport error. Only the former is a quiescence observation.
+            handler = object.__new__(DockerHandler)
+            ExecutionHandler.__init__(handler, backend_type=Backend.LOCAL_DOCKER)
+            handler._docker_client = docker_client
+            handler._api_client = docker_client.api
+            handler._container = None
+            handler._docker_image = None
+            handler._docker_registry = None
+            handler._image_name = None
+            handler._docker_tag = None
+            handler._container_absence_confirmed = True
+            return handler
         except Exception as e:
             logger.error(traceback.format_exc())
             logger.error(f"Error getting handler for container {container_name}: {e}")
@@ -377,10 +659,32 @@ class DockerHandler(ExecutionHandler):
             command: Command to run in the container
             num_gpus: Number of GPUs to assign (-1 for all)
             volumes: Volume mounts for the container
+
+                Writable ``/results`` mounts are a fail-closed integration contract: the
+                service must provide the verified host submitter identity in
+                ``TAO_DOCKER_CONTAINER_USER`` (and supplementary numeric GIDs
+                in ``TAO_DOCKER_GROUP_ADD`` when needed). Callers must never
+                derive those values from a bind directory owner. Read-only and
+                Docker-socket-only launches preserve the image's default user.
         """
         try:
             # Use container_name as job_id for status updates
             job_id = container_name if container_name else None
+
+            # Parse and validate the trusted host identity before an image pull
+            # can consume more disk. The daemon-side write/delete proof still
+            # runs after the requested workload image is locally available.
+            writable_mounts = _writable_bind_mounts(volumes)
+            has_results_bind = any(
+                target.rstrip("/") == "/results"
+                for _source, target, _mode in writable_mounts
+            )
+            configured_identity = None
+            identity_mapping_verified = False
+            if has_results_bind:
+                configured_identity = _configured_container_identity()
+                self._assert_host_identity_mapping_supported()
+                identity_mapping_verified = True
 
             # Update status: checking if image exists
             if job_id:
@@ -401,6 +705,20 @@ class DockerHandler(ExecutionHandler):
                 # Image already exists locally
                 if job_id:
                     self.update_image_pull_status(job_id, self._docker_image, "already_exists")
+
+            bind_runtime = self._prepare_writable_bind_runtime(
+                volumes,
+                writable_mounts=writable_mounts,
+                configured_identity=configured_identity,
+                identity_mapping_verified=identity_mapping_verified,
+            )
+            effective_env = dict(docker_env_vars or {})
+            if bind_runtime:
+                container_user, supplementary_groups, ownership_env = bind_runtime
+                # The ownership redirects are invariants for writable host
+                # output mounts, so per-job environment values cannot point
+                # HOME or framework caches back into image-owned locations.
+                effective_env.update(ownership_env)
 
             # Check for pre-assigned GPUs in three places (in order of priority):
             # 1. Passed directly as parameter
@@ -477,26 +795,27 @@ class DockerHandler(ExecutionHandler):
                 "tmpfs": {"/dev/shm": ""},
                 "detach": True,
                 "remove": True,
-                "environment": docker_env_vars,
+                "environment": effective_env,
                 "volumes": volumes,
             }
+            if bind_runtime:
+                run_kwargs["user"] = container_user
+                if supplementary_groups:
+                    run_kwargs["group_add"] = supplementary_groups
 
             if use_runtime:
                 # Method 1: Use runtime="nvidia" (for Tegra/Jetson and nvidia-docker2)
                 # This matches the tao_pt.py runner behavior:
                 # --runtime=nvidia -e NVIDIA_DRIVER_CAPABILITIES=all -e NVIDIA_VISIBLE_DEVICES=<gpus>
-                docker_env_vars = docker_env_vars.copy()
-                docker_env_vars["NVIDIA_DRIVER_CAPABILITIES"] = "all"
+                effective_env["NVIDIA_DRIVER_CAPABILITIES"] = "all"
                 if gpu_ids:
-                    docker_env_vars["NVIDIA_VISIBLE_DEVICES"] = ",".join(gpu_ids)
+                    effective_env["NVIDIA_VISIBLE_DEVICES"] = ",".join(gpu_ids)
                     logger.info(f"Using runtime='nvidia' with GPUs: {','.join(gpu_ids)}")
                 else:
-                    docker_env_vars["NVIDIA_VISIBLE_DEVICES"] = "all"
+                    effective_env["NVIDIA_VISIBLE_DEVICES"] = "all"
                     logger.info("Using runtime='nvidia' with all available GPUs")
 
                 run_kwargs["runtime"] = "nvidia"
-                docker_env_vars = docker_env_vars.copy()
-                docker_env_vars["NVIDIA_DRIVER_CAPABILITIES"] = "all"
             else:
                 # Method 2: Use device_requests (for standard Docker with nvidia-container-toolkit)
                 device_requests = self.get_device_requests(gpu_ids)
@@ -673,13 +992,28 @@ class DockerHandler(ExecutionHandler):
         Args:
             job_id: Job/microservice identifier
         """
-        if BACKEND == Backend.LOCAL_DOCKER:
-            from nvidia_tao_core.microservices.utils.job_utils.gpu_manager import gpu_manager
+        if getattr(self, "_container_absence_confirmed", False):
+            return True
+        if not self._container:
+            self.logger.error("No confirmed Docker container state for %s", job_id)
+            return False
+        try:
             self.stop_container()
-            gpu_manager.release_gpus(job_id)
+            try:
+                self._container.reload()
+                if self._container.status == "running":
+                    self.logger.error("Docker container %s is still running", job_id)
+                    return False
+            except docker.errors.NotFound:
+                pass
+            if BACKEND == Backend.LOCAL_DOCKER:
+                from nvidia_tao_core.microservices.utils.job_utils.gpu_manager import gpu_manager
+                gpu_manager.release_gpus(job_id)
             self.logger.info(f"Deleted Docker microservice {job_id}")
-        else:
-            self.stop_container()
+            return True
+        except Exception as err:
+            self.logger.error("Failed to stop Docker microservice %s: %s", job_id, err)
+            return False
 
     def get_job_status(self, job_id, **kwargs):
         """Get job status - unified interface for ExecutionHandler
@@ -728,8 +1062,9 @@ class DockerHandler(ExecutionHandler):
         if self._container:
             logger.info(f"Stopping container: {self._container.name}")
             self._container.stop()
-        else:
-            logger.error("No container to stop")
+            return True
+        logger.error("No container to stop")
+        return False
 
     def wait_for_container(self, job_id, port=8000):
         """Wait for the container to be ready."""

--- a/nvidia_tao_core/microservices/handlers/execution_handlers/execution_handler.py
+++ b/nvidia_tao_core/microservices/handlers/execution_handlers/execution_handler.py
@@ -1198,9 +1198,12 @@ class ExecutionHandler(ABC):
             )
             if not handler:
                 logger.error(f"Unable to determine appropriate handler for backend '{BACKEND}' and job_id '{job_id}'")
-                return True
-            handler.delete(job_id)
-            return True
+                return False
+            result = handler.delete(job_id)
+            # Backends that can confirm termination return a boolean. Preserve
+            # compatibility with legacy handlers that return None on success,
+            # but never discard an explicit cancellation failure.
+            return result is not False
 
         except Exception as e:
             logger.error(f"Failed to delete job {job_id}: {str(e)}")
@@ -1414,7 +1417,7 @@ class ExecutionHandler(ABC):
             handler = ExecutionHandler.create_handler(backend=BACKEND, job_id=job_name)
             if not handler:
                 logger.error(f"Unable to determine appropriate handler for backend '{BACKEND}' and job_id '{job_name}'")
-                return True
+                return False
             if handler.backend_type == Backend.LOCAL_K8S:
                 from .kubernetes_handler import KubernetesHandler
                 k8s_handler = KubernetesHandler()
@@ -1429,9 +1432,12 @@ class ExecutionHandler(ABC):
                 else:
                     k8s_handler.delete_service(job_id=job_name, service_type="flask")
                     k8s_handler.delete_job(job_name)
-            else:
-                handler.delete(job_name)
-            return True
+                # Kubernetes deletion is asynchronous; callers that need a
+                # quiescence barrier must follow this accepted request with
+                # ``wait_for_job_termination``.
+                return True
+            result = handler.delete(job_name)
+            return result is not False
         except Exception as e:
             logger.error(f"Failed to delete job {job_name}: {str(e)}")
             logger.error(traceback.format_exc())

--- a/nvidia_tao_core/microservices/handlers/execution_handlers/kubernetes_handler.py
+++ b/nvidia_tao_core/microservices/handlers/execution_handlers/kubernetes_handler.py
@@ -479,10 +479,36 @@ class KubernetesHandler(ExecutionHandler):
         """
         try:
             resource_type = kwargs.get("resource_type", "multinode")
-            self.delete_statefulset(job_id, use_ngc=False, resource_type=resource_type)
+            deleted = self.delete_statefulset(
+                job_id, use_ngc=False, resource_type=resource_type
+            )
+            if deleted is False:
+                return False
+
+            # Foreground deletion is asynchronous at the Kubernetes API
+            # boundary. Confirm that no labeled pod remains before callers
+            # remove bind-mounted checkpoints.
+            core_api = client.CoreV1Api()
+            namespace = self.get_namespace()
+            deadline = time.monotonic() + 30
+            while True:
+                pods = core_api.list_namespaced_pod(
+                    namespace=namespace,
+                    label_selector=f"job-id={job_id}",
+                ).items
+                if not pods:
+                    break
+                if time.monotonic() >= deadline:
+                    self.logger.error(
+                        "Timed out waiting for pods of %s to terminate", job_id
+                    )
+                    return False
+                time.sleep(0.5)
             self.logger.info(f"Deleted K8s microservice {job_id}")
+            return True
         except Exception as e:
             self.logger.error(f"Failed to delete K8s microservice: {e}")
+            return False
 
     def _get_pod_image_pull_status(self, pod_name, namespace):
         """Get the image pull status from a pod's events and container statuses.

--- a/nvidia_tao_core/microservices/handlers/execution_handlers/slurm_handler.py
+++ b/nvidia_tao_core/microservices/handlers/execution_handlers/slurm_handler.py
@@ -2059,7 +2059,8 @@ class SlurmHandler(ExecutionHandler):
                 check=False
             )
 
-            if result.returncode == 0 and result.stdout.strip():
+            squeue_failed = result.returncode != 0
+            if not squeue_failed and result.stdout.strip():
                 status = result.stdout.strip()
                 self.logger.info(f"SLURM job {slurm_job_id} active status: {status}")
                 return status
@@ -2077,7 +2078,8 @@ class SlurmHandler(ExecutionHandler):
                 check=False
             )
 
-            if result.returncode == 0 and result.stdout.strip():
+            sacct_failed = result.returncode != 0
+            if not sacct_failed and result.stdout.strip():
                 # sacct returns multiple lines (parent job + steps), take first non-empty
                 for line in result.stdout.strip().split('\n'):
                     if line.strip():
@@ -2085,6 +2087,14 @@ class SlurmHandler(ExecutionHandler):
                         self.logger.info(f"SLURM job {slurm_job_id} historical status: {status}")
                         return status
 
+            if squeue_failed or sacct_failed:
+                self.logger.error(
+                    "Unable to query SLURM job %s (squeue rc=%s, sacct rc=%s)",
+                    slurm_job_id,
+                    "non-zero" if squeue_failed else "0",
+                    "non-zero" if sacct_failed else "0",
+                )
+                return "ERROR"
             self.logger.warning(f"SLURM job {slurm_job_id} not found in squeue or sacct")
             return "NOT_FOUND"
 
@@ -2982,7 +2992,7 @@ class SlurmHandler(ExecutionHandler):
             if not job_metadata:
                 self.logger.warning(f"No metadata found for job {job_id}")
                 self.logger.info("=" * 80)
-                return True  # Consider it success if job doesn't exist
+                return True
 
             # Check if this is AutoML experiment - get SLURM job ID from controller info
             slurm_job_id = self.get_slurm_job_id(job_id)
@@ -2991,16 +3001,26 @@ class SlurmHandler(ExecutionHandler):
                 self.logger.warning(f"No SLURM job ID found for TAO job {job_id}")
                 self.logger.info("Job may not have been submitted to SLURM yet, or already completed")
                 self.logger.info("=" * 80)
-                return True  # No SLURM job to cancel
+                return True
 
             # Check if job is already completed
             slurm_status = self.get_slurm_job_status(slurm_job_id)
-            if not slurm_status:
-                self.logger.info(f"SLURM job {slurm_job_id} not found (may have already completed)")
+            if slurm_status == "NOT_FOUND":
+                self.logger.info(f"SLURM job {slurm_job_id} is absent from queue and accounting")
                 self.logger.info("=" * 80)
                 return True
 
-            if slurm_status in ("COMPLETED", "FAILED", "CANCELLED", "TIMEOUT"):
+            if slurm_status == "ERROR":
+                self.logger.error(f"Could not confirm status of SLURM job {slurm_job_id}")
+                self.logger.info("=" * 80)
+                return False
+
+            terminal_states = (
+                "COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL",
+                "OUT_OF_MEMORY", "PREEMPTED", "REVOKED", "BOOT_FAIL", "DEADLINE",
+            )
+            normalized_status = str(slurm_status).split()[0].split("+", 1)[0]
+            if normalized_status in terminal_states:
                 self.logger.info(f"SLURM job {slurm_job_id} already terminated with status: {slurm_status}")
                 self.logger.info("=" * 80)
                 return True
@@ -3019,13 +3039,39 @@ class SlurmHandler(ExecutionHandler):
             )
 
             if result.returncode == 0:
-                self.logger.info(f"Successfully canceled SLURM job {slurm_job_id}")
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    terminal_status = self.get_slurm_job_status(slurm_job_id)
+                    normalized_terminal_status = (
+                        str(terminal_status).split()[0].split("+", 1)[0]
+                    )
+                    if terminal_status == "ERROR":
+                        self.logger.error(
+                            "Could not confirm terminal status of SLURM job %s",
+                            slurm_job_id,
+                        )
+                        return False
+                    if terminal_status == "NOT_FOUND" or normalized_terminal_status in terminal_states:
+                        self.logger.info(
+                            "SLURM job %s terminated with status: %s",
+                            slurm_job_id,
+                            terminal_status or "NOT_FOUND",
+                        )
+                        self.update_job_status(
+                            job_id,
+                            "CANCELLED",
+                            f"SLURM job {slurm_job_id} canceled by user",
+                        )
+                        self.logger.info("=" * 80)
+                        return True
+                    time.sleep(0.5)
 
-                # Update job message to reflect cancellation
-                self.update_job_status(job_id, "CANCELLED", f"SLURM job {slurm_job_id} canceled by user")
-
+                self.logger.error(
+                    "Timed out waiting for SLURM job %s to terminate after scancel",
+                    slurm_job_id,
+                )
                 self.logger.info("=" * 80)
-                return True
+                return False
 
             error_msg = result.stderr.strip() if result.stderr else result.stdout.strip()
             # scancel returns non-zero if job doesn't exist (already terminated)

--- a/nvidia_tao_core/microservices/handlers/job_handler.py
+++ b/nvidia_tao_core/microservices/handlers/job_handler.py
@@ -635,6 +635,12 @@ class JobHandler:
             update_job_status(handler_id, job_id, status="Canceling", kind=kind + "s")
             logger.debug(f"[CANCEL] Job status updated to Canceling: job_id={job_id}")
             automl_response = AutoMLHandler.stop(user_id, org_name, handler_id, job_id)
+            if automl_response.code != 200:
+                logger.warning(
+                    "[CANCEL] AutoML cancellation remains pending: job_id=%s response=%s",
+                    job_id, automl_response.code,
+                )
+                return automl_response
             # Remove any pending jobs from Workflow queue
             try:
                 logger.debug(f"[CANCEL] Removing pending AutoML jobs from workflow: job_id={job_id}")
@@ -779,7 +785,15 @@ class JobHandler:
             logger.debug(f"[PAUSE] Processing AutoML pause: job_id={job_id}, handler_id={handler_id}")
             update_job_status(handler_id, job_id, status="Pausing", kind=kind + "s")
             logger.debug(f"[PAUSE] Job status updated to Pausing: job_id={job_id}")
-            automl_response = AutoMLHandler.stop(user_id, org_name, handler_id, job_id)
+            automl_response = AutoMLHandler.stop(
+                user_id, org_name, handler_id, job_id, cleanup_checkpoints=False
+            )
+            if automl_response.code != 200:
+                logger.warning(
+                    "[PAUSE] AutoML pause remains pending: job_id=%s response=%s",
+                    job_id, automl_response.code,
+                )
+                return automl_response
             # Remove any pending jobs from Workflow queue
             try:
                 logger.debug(f"[PAUSE] Removing pending AutoML jobs from workflow: job_id={job_id}")

--- a/nvidia_tao_core/microservices/utils/automl_job_utils.py
+++ b/nvidia_tao_core/microservices/utils/automl_job_utils.py
@@ -4,10 +4,12 @@
 """Util functions for AutoML jobs"""
 import logging
 import os
+from copy import deepcopy
 
 from .stateless_handler_utils import (
     get_public_experiments,
     get_handler_job_metadata,
+    get_handler_metadata,
     write_job_metadata,
     get_job_specs,
     get_job
@@ -160,17 +162,29 @@ def on_cancel_automl_job(job_id):
     )
 
     # Get workspace metadata to enable SLURM/Lepton job cancellation
-    from .stateless_handler_utils import get_handler_job_metadata, get_handler_metadata
     job_metadata = get_handler_job_metadata(job_id)
     workspace_metadata = {}
     if job_metadata:
-        handler_id = job_metadata.get('parent_id')  # AutoML brain job ID
-        if handler_id:
-            handler_metadata = get_handler_metadata(handler_id, kind='experiments')
+        # Child ``parent_id`` is the AutoML brain job ID, not the experiment ID.
+        # Prefer the child's durable handler_id and fall back through brain metadata.
+        experiment_id = job_metadata.get('handler_id') or job_metadata.get('experiment_id')
+        if not experiment_id:
+            brain_job_id = job_metadata.get('parent_id')
+            brain_metadata = get_handler_job_metadata(brain_job_id) if brain_job_id else {}
+            experiment_id = (
+                brain_metadata.get('experiment_id') or brain_metadata.get('handler_id')
+            )
+        if experiment_id:
+            handler_metadata = get_handler_metadata(experiment_id, kind='experiments')
             if handler_metadata:
                 workspace_id = handler_metadata.get('workspace')
                 if workspace_id:
                     workspace_metadata = get_handler_metadata(workspace_id, kind='workspaces')
+                    if workspace_metadata:
+                        from .handler_utils import decrypt_handler_metadata
+                        workspace_metadata = deepcopy(workspace_metadata)
+                        decrypt_handler_metadata(workspace_metadata)
+                        workspace_metadata.pop('_id', None)
 
     from nvidia_tao_core.microservices.handlers.execution_handlers.execution_handler import ExecutionHandler
     result = ExecutionHandler.delete_with_handler(job_id, workspace_metadata=workspace_metadata)
@@ -181,3 +195,56 @@ def on_cancel_automl_job(job_id):
         logger.error(f"Failed to delete StatefulSet for AutoML job {job_id}")
 
     return result
+
+
+def cancel_automl_child_job(job_id):
+    """Fence, dequeue, and confirm quiescence of one AutoML child.
+
+    The durable cancellation tombstone is written before the workflow queue or
+    backend is touched. A launcher already in ``submitting`` must finish its
+    pre/post-create handshake before this function can report quiescence.
+    """
+    from .stateless_handler_utils import (
+        get_automl_child_lifecycle,
+        request_automl_child_cancellation,
+        set_automl_child_launch_state,
+    )
+
+    if not request_automl_child_cancellation(job_id):
+        logger.error("Unable to persist AutoML cancellation intent for child %s", job_id)
+        return False
+
+    # Remove a not-yet-started job before checking platform state. The atomic
+    # launch claim also observes the tombstone, closing the dequeue/spawn race.
+    try:
+        on_delete_automl_job(job_id)
+    except Exception as err:
+        logger.error("Unable to dequeue AutoML child %s: %s", job_id, err)
+        return False
+
+    lifecycle = get_automl_child_lifecycle(job_id)
+    if lifecycle["launch_state"] == "quiescent":
+        return True
+
+    deletion_confirmed = on_cancel_automl_job(job_id) is True
+    lifecycle = get_automl_child_lifecycle(job_id)
+    if lifecycle["launch_state"] == "quiescent":
+        # The launcher may have observed the tombstone and completed its own
+        # exact post-create deletion while this cancellation attempt was in
+        # flight. Never overwrite that stronger acknowledgement with failure.
+        return True
+    if lifecycle["launch_state"] == "submitting":
+        logger.info(
+            "AutoML child %s is still inside its backend launch handshake", job_id
+        )
+        return False
+    if not deletion_confirmed:
+        set_automl_child_launch_state(
+            job_id, "cancel_failed", "backend quiescence was not confirmed"
+        )
+        return False
+
+    if not set_automl_child_launch_state(job_id, "quiescent"):
+        logger.error("Unable to persist quiescent state for AutoML child %s", job_id)
+        return False
+    return True

--- a/nvidia_tao_core/microservices/utils/handler_utils.py
+++ b/nvidia_tao_core/microservices/utils/handler_utils.py
@@ -97,7 +97,7 @@ def Code(code, data={}, msg="", use_data_as_response=False):
     if code == 200:
         return TAOResponse(code, data, msg)
 
-    if code in [400, 404]:
+    if code in [400, 404, 409]:
         if use_data_as_response:
             # Use data directly as response, just like 200 responses
             return TAOResponse(code, data, msg)

--- a/nvidia_tao_core/microservices/utils/job_utils/dependencies.py
+++ b/nvidia_tao_core/microservices/utils/job_utils/dependencies.py
@@ -253,7 +253,17 @@ def dependency_check_automl(job_context, dependency):
     if not recs_dict:
         return False, f"Automl controller for brain job id {automl_brain_job_id} not found yet"
     try:
-        recs_dict[rec_number]
+        recommendation = recs_dict[rec_number]
+        child_metadata = get_handler_job_metadata(str(job_context.id)) or {}
+        parent_metadata = get_handler_job_metadata(automl_brain_job_id) or {}
+        if (
+            child_metadata.get("automl_cancel_requested") is True or
+            str(recommendation.get("status", "")).lower() in ("canceled", "canceling") or
+            str(parent_metadata.get("status", "")).lower() in (
+                "canceled", "canceling", "paused", "pausing"
+            )
+        ):
+            return False, "AutoML recommendation cancellation has been requested"
         return True, ""
     except Exception as e:
         logger.error("Exception thrown in dependency_check_automl: %s", str(e))

--- a/nvidia_tao_core/microservices/utils/slurm_cloud_storage.py
+++ b/nvidia_tao_core/microservices/utils/slurm_cloud_storage.py
@@ -660,8 +660,12 @@ class SlurmCloudStorageAdapter:
 
         if success:
             logger.info(f"Deleted folder: {full_path}")
-        else:
-            logger.error(f"Failed to delete folder {full_path}: {stderr}")
+            return True
+        logger.error(f"Failed to delete folder {full_path}: {stderr}")
+        raise RuntimeError(
+            f"Failed to delete folder {full_path}: "
+            f"{stderr or 'remote rm returned a non-zero status'}"
+        )
 
     @retry_on_connection_error(max_retries=2, initial_delay=3, backoff_factor=2)
     def delete_file(self, file_path):
@@ -672,8 +676,12 @@ class SlurmCloudStorageAdapter:
 
         if success:
             logger.info(f"Deleted file: {full_path}")
-        else:
-            logger.error(f"Failed to delete file {full_path}: {stderr}")
+            return True
+        logger.error(f"Failed to delete file {full_path}: {stderr}")
+        raise RuntimeError(
+            f"Failed to delete file {full_path}: "
+            f"{stderr or 'remote rm returned a non-zero status'}"
+        )
 
     @retry_on_connection_error(max_retries=5, initial_delay=30, backoff_factor=2)
     def move_file(self, source_path, destination_path):

--- a/nvidia_tao_core/microservices/utils/stateless_handler_utils.py
+++ b/nvidia_tao_core/microservices/utils/stateless_handler_utils.py
@@ -322,6 +322,142 @@ def write_job_metadata(job_id, metadata):
     mongo_jobs.upsert(jobs_query, metadata)
 
 
+AUTOML_NONQUIESCENT_LAUNCH_STATES = frozenset({
+    "submitting", "running", "uncertain", "cancel_failed"
+})
+
+
+def get_automl_child_lifecycle(job_id):
+    """Return the durable launch/cancel handshake for an AutoML child job."""
+    metadata = get_handler_job_metadata(job_id) or {}
+    return {
+        "cancel_requested": bool(metadata.get("automl_cancel_requested", False)),
+        "launch_state": metadata.get("automl_launch_state", "queued"),
+        "error": metadata.get("automl_launch_error", ""),
+    }
+
+
+def get_automl_child_job_ids(brain_job_id):
+    """Return every durable workflow child associated with an AutoML brain."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    return [
+        job.get("id")
+        for job in mongo_jobs.find({"parent_id": brain_job_id})
+        if job.get("id")
+    ]
+
+
+def request_automl_child_cancellation(job_id):
+    """Durably fence an AutoML child so no new platform launch may start."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {"id": job_id},
+        {
+            "$set": {
+                "automl_cancel_requested": True,
+                "automl_cancel_requested_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.matched_count == 1
+
+
+def claim_automl_child_launch(job_id):
+    """Atomically claim the right to submit an AutoML child to its backend.
+
+    A cancellation tombstone wins over a concurrent launch claim. The caller must
+    transition ``submitting`` to ``running``, ``uncertain``, or ``quiescent``.
+    """
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {
+            "id": job_id,
+            "automl_cancel_requested": {"$ne": True},
+            "automl_launch_state": {
+                "$nin": list(AUTOML_NONQUIESCENT_LAUNCH_STATES)
+            },
+        },
+        {
+            "$set": {
+                "automl_launch_state": "submitting",
+                "automl_launch_error": "",
+                "automl_launch_updated_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.modified_count == 1
+
+
+def claim_automl_child_relaunch(job_id):
+    """Atomically move a running child back into a fenced submit phase."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {
+            "id": job_id,
+            "automl_cancel_requested": {"$ne": True},
+            "automl_launch_state": "running",
+        },
+        {
+            "$set": {
+                "automl_launch_state": "submitting",
+                "automl_launch_error": "",
+                "automl_launch_updated_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.modified_count == 1
+
+
+def set_automl_child_launch_state(job_id, state, error=""):
+    """Persist an AutoML child launch state without replacing other job fields."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {"id": job_id},
+        {
+            "$set": {
+                "automl_launch_state": state,
+                "automl_launch_error": str(error) if error else "",
+                "automl_launch_updated_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.matched_count == 1
+
+
+def reset_automl_child_lifecycle_for_resume(job_id):
+    """Re-arm a quiescent child when an explicitly paused AutoML run resumes."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {"id": job_id},
+        {
+            "$set": {
+                "automl_cancel_requested": False,
+                "automl_launch_state": "queued",
+                "automl_launch_error": "",
+                "automl_launch_updated_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.modified_count == 1
+
+
+def set_automl_checkpoint_cleanup_state(job_id, state, error=""):
+    """Persist the parent AutoML checkpoint-cleanup retry state."""
+    mongo_jobs = MongoHandler("tao", "jobs")
+    result = mongo_jobs.collection.update_one(
+        {"id": job_id},
+        {
+            "$set": {
+                "checkpoint_cleanup_pending": state not in ("complete", "skipped"),
+                "checkpoint_cleanup_status": state,
+                "checkpoint_cleanup_error": str(error) if error else "",
+                "checkpoint_cleanup_updated_at": datetime.now(tz=timezone.utc),
+            }
+        },
+    )
+    return result.matched_count == 1
+
+
 def get_job_id_of_action(handler_id, kind, action):
     """Find jobID within a handler matching an action"""
     handler_job_id = None

--- a/nvidia_tao_core/tests/dinov3/__init__.py
+++ b/nvidia_tao_core/tests/dinov3/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 config tests."""

--- a/nvidia_tao_core/tests/dinov3/test_config.py
+++ b/nvidia_tao_core/tests/dinov3/test_config.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test cases for the DINOv3 dataclass config and its jsonschema conversion.
+
+The DINOv3 config in tao-core is the source of truth for the generated skill
+schemas in tao-skills-external and must stay aligned with
+``nvidia_tao_pytorch.config.dinov3.default_config`` (bug 6465432).
+"""
+
+from nvidia_tao_core.api_utils.dataclass2json_converter import (
+    create_json_schema,
+    dataclass_to_json,
+)
+from nvidia_tao_core.config.dinov3.default_config import (
+    DINOv3CuDNNConfig,
+    DINOv3ExportExpConfig,
+    DINOv3TrainExpConfig,
+    DINOv3TransformConfig,
+    ExperimentConfig,
+    SUPPORTED_BACKBONES,
+    SUPPORTED_IMAGE_SIZES,
+    map_params,
+)
+
+# Must match nvidia_tao_pytorch.config.dinov3.default_config.SUPPORTED_BACKBONES.
+EXPECTED_BACKBONES = ["vit_s", "vit_s_plus", "vit_b", "vit_l", "vit_h_plus", "vit_7b"]
+EXPECTED_PRETRAINED_DESCRIPTION = (
+    "Path to DINOv3 pretrained weights matching the configured backbone. "
+    "Accepts a timm-format directory or file, or a stripped TAO DINOv3 "
+    "backbone checkpoint. DINOv2/NVDINOv2 checkpoints are not supported."
+)
+
+
+def test_supported_backbones_match_tao_pytorch():
+    assert SUPPORTED_BACKBONES == EXPECTED_BACKBONES
+
+
+def test_cudnn_defaults_match_dinov3_templates():
+    config = ExperimentConfig()
+    assert config.train.cudnn.benchmark is True
+    assert config.train.cudnn.deterministic is False
+
+    fields = DINOv3CuDNNConfig.__dataclass_fields__
+    assert fields["benchmark"].metadata["description"]
+    assert fields["benchmark"].metadata["display_name"] == "CuDNN benchmark"
+    assert fields["benchmark"].metadata["popular"] == "no"
+    assert fields["deterministic"].metadata["description"]
+    assert fields["deterministic"].metadata["display_name"] == "CuDNN deterministic"
+    assert fields["deterministic"].metadata["popular"] == "no"
+
+    schema = create_json_schema(dataclass_to_json(config))
+    cudnn = schema["properties"]["train"]["properties"]["cudnn"]
+    assert cudnn["default"] == {"benchmark": True, "deterministic": False}
+    assert cudnn["properties"]["benchmark"]["default"] is True
+    assert cudnn["properties"]["benchmark"]["description"]
+    assert cudnn["properties"]["benchmark"]["title"] == "CuDNN benchmark"
+    assert cudnn["properties"]["deterministic"]["default"] is False
+    assert cudnn["properties"]["deterministic"]["description"]
+    assert cudnn["properties"]["deterministic"]["title"] == "CuDNN deterministic"
+
+
+def test_pretrained_model_path_description_is_dinov3_specific():
+    """DINOv3 metadata must not inherit the NVDINOv2 checkpoint contract."""
+    field = DINOv3TrainExpConfig.__dataclass_fields__["pretrained_model_path"]
+    assert field.metadata["description"] == EXPECTED_PRETRAINED_DESCRIPTION
+    assert field.metadata["default_value"] is None
+
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    pretrained = schema["properties"]["train"]["properties"]["pretrained_model_path"]
+    assert pretrained["description"] == EXPECTED_PRETRAINED_DESCRIPTION
+    assert "default" not in pretrained
+
+
+def test_global_crop_description_is_not_single_resolution():
+    """DINOv3 transform metadata must not imply that only 256 is supported."""
+    field = DINOv3TransformConfig.__dataclass_fields__["global_crops_size"]
+    assert field.metadata["description"] == "Size of global crops for DINOv3 training."
+
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    global_crops_size = (
+        schema["properties"]["dataset"]["properties"]["transform"]["properties"]["global_crops_size"]
+    )
+    assert global_crops_size["description"] == field.metadata["description"]
+
+
+def test_map_params_cover_all_backbones():
+    for param, per_arch in map_params.items():
+        assert sorted(per_arch.keys()) == sorted(EXPECTED_BACKBONES), (
+            f"map_params[{param!r}] does not cover all supported backbones"
+        )
+
+
+def test_backbone_enum_in_json_schema():
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    backbone = schema["properties"]["model"]["properties"]["backbone"]["properties"]
+    assert backbone["teacher_type"]["enum"] == EXPECTED_BACKBONES
+    assert backbone["student_type"]["enum"] == EXPECTED_BACKBONES
+    assert backbone["teacher_type"]["default"] == "vit_b"
+    assert backbone["student_type"]["default"] == "vit_b"
+    assert SUPPORTED_IMAGE_SIZES == (256, 512, 768)
+    assert backbone["img_size"]["enum"] == list(SUPPORTED_IMAGE_SIZES)
+    assert backbone["img_size"]["description"] == (
+        "Backbone image size. Supported values are 256, 512, and 768."
+    )
+
+
+def test_experiment_config_actions():
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    for action in ("train", "inference", "export", "gen_trt_engine", "convert"):
+        assert action in schema["properties"], f"missing {action} section"
+
+
+def test_export_checkpoint_contract_selects_teacher():
+    """The generated schema documents teacher selection for full checkpoints."""
+    field = DINOv3ExportExpConfig.__dataclass_fields__["checkpoint"]
+    assert "full Lightning training checkpoint" in field.metadata["description"]
+    assert "always selects the EMA teacher backbone" in field.metadata["description"]
+
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    checkpoint = schema["properties"]["export"]["properties"]["checkpoint"]
+    assert checkpoint["description"] == field.metadata["description"]
+    assert checkpoint["title"] == "Path to checkpoint file"
+
+
+def test_export_trace_shape_matches_backbone():
+    """Export ONNX trace defaults match the patch-16 backbone (256, not nvdinov2's 518)."""
+    schema = create_json_schema(dataclass_to_json(ExperimentConfig()))
+    export = schema["properties"]["export"]["properties"]
+    patch_size = schema["properties"]["model"]["properties"]["backbone"]["properties"]["patch_size"]["default"]
+    assert export["input_width"]["default"] == 256
+    assert export["input_height"]["default"] == 256
+    assert export["input_width"]["default"] % patch_size == 0
+    assert export["input_height"]["default"] % patch_size == 0

--- a/nvidia_tao_core/tests/microservices/automl/test_cancellation_handshake.py
+++ b/nvidia_tao_core/tests/microservices/automl/test_cancellation_handshake.py
@@ -1,0 +1,434 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Race and API-boundary tests for the AutoML cancellation barrier."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+
+os.environ["TAO_TEST_MODE"] = "true"
+
+from nvidia_tao_core.microservices.enum_constants import Backend  # noqa: E402
+from nvidia_tao_core.microservices.automl.controller import Controller  # noqa: E402
+from nvidia_tao_core.microservices.utils.automl_utils import (  # noqa: E402
+    JobStates,
+    Recommendation,
+    ResumeRecommendation,
+)
+from nvidia_tao_core.microservices.handlers.actions import AutoMLPipeline  # noqa: E402
+from nvidia_tao_core.microservices.handlers.automl_handler import AutoMLHandler  # noqa: E402
+from nvidia_tao_core.microservices.handlers.execution_handlers.execution_handler import (  # noqa: E402
+    ExecutionHandler,
+)
+from nvidia_tao_core.microservices.handlers.job_handler import JobHandler  # noqa: E402
+from nvidia_tao_core.microservices.utils.automl_job_utils import (  # noqa: E402
+    cancel_automl_child_job,
+    on_cancel_automl_job,
+)
+from nvidia_tao_core.microservices.utils.handler_utils import Code  # noqa: E402
+from nvidia_tao_core.microservices.utils.job_utils.dependencies import (  # noqa: E402
+    dependency_check_automl,
+)
+
+
+ACTIONS_MODULE = "nvidia_tao_core.microservices.handlers.actions"
+CONTROLLER_MODULE = "nvidia_tao_core.microservices.automl.controller"
+AUTOML_HANDLER_MODULE = "nvidia_tao_core.microservices.handlers.automl_handler"
+AUTOML_JOB_UTILS_MODULE = "nvidia_tao_core.microservices.utils.automl_job_utils"
+DEPENDENCIES_MODULE = "nvidia_tao_core.microservices.utils.job_utils.dependencies"
+JOB_HANDLER_MODULE = "nvidia_tao_core.microservices.handlers.job_handler"
+
+
+def test_canceled_automl_dependency_is_never_runnable():
+    """A queued recommendation cannot pass dependency checks after fencing."""
+    job_context = SimpleNamespace(id="child-0", parent_id="brain-0")
+    dependency = SimpleNamespace(name="0")
+    with (
+        patch(
+            f"{DEPENDENCIES_MODULE}.get_automl_controller_info",
+            return_value=[{"job_id": "child-0", "status": "pending"}],
+        ),
+        patch(
+            f"{DEPENDENCIES_MODULE}.get_handler_job_metadata",
+            side_effect=[
+                {"automl_cancel_requested": True},
+                {"status": "Running"},
+            ],
+        ),
+    ):
+        dependency_met, message = dependency_check_automl(job_context, dependency)
+
+    assert dependency_met is False
+    assert "cancellation" in message.lower()
+
+
+def test_missing_execution_handler_fails_closed():
+    """An unknown backend is not evidence that its writer has stopped."""
+    with patch.object(ExecutionHandler, "create_handler", return_value=None):
+        assert ExecutionHandler.delete_with_handler("child-0", {}) is False
+        assert ExecutionHandler.delete_job_with_handler("brain-0") is False
+
+
+def test_submitting_child_is_not_quiescent_even_if_delete_found_no_resource():
+    """Cancellation waits for the launcher handshake after a pre-create delete."""
+    lifecycle = {
+        "cancel_requested": True,
+        "launch_state": "submitting",
+        "error": "",
+    }
+    with (
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "request_automl_child_cancellation",
+            return_value=True,
+        ),
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "get_automl_child_lifecycle",
+            side_effect=[lifecycle, lifecycle],
+        ),
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "set_automl_child_launch_state"
+        ) as set_launch_state,
+        patch(f"{AUTOML_JOB_UTILS_MODULE}.on_delete_automl_job"),
+        patch(f"{AUTOML_JOB_UTILS_MODULE}.on_cancel_automl_job", return_value=True),
+    ):
+        assert cancel_automl_child_job("child-0") is False
+
+    set_launch_state.assert_not_called()
+
+
+def test_launcher_quiescence_wins_over_concurrent_delete_failure():
+    """A launcher's stronger post-create acknowledgement is never downgraded."""
+    submitting = {
+        "cancel_requested": True,
+        "launch_state": "submitting",
+        "error": "",
+    }
+    quiescent = {
+        "cancel_requested": True,
+        "launch_state": "quiescent",
+        "error": "",
+    }
+    with (
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "request_automl_child_cancellation",
+            return_value=True,
+        ),
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "get_automl_child_lifecycle",
+            side_effect=[submitting, quiescent],
+        ),
+        patch(
+            "nvidia_tao_core.microservices.utils.stateless_handler_utils."
+            "set_automl_child_launch_state"
+        ) as set_launch_state,
+        patch(f"{AUTOML_JOB_UTILS_MODULE}.on_delete_automl_job"),
+        patch(f"{AUTOML_JOB_UTILS_MODULE}.on_cancel_automl_job", return_value=False),
+    ):
+        assert cancel_automl_child_job("child-0") is True
+
+    set_launch_state.assert_not_called()
+
+
+def test_automl_pipeline_honors_fence_before_backend_create():
+    """A tombstone observed after the launch claim prevents resource creation."""
+    pipeline = AutoMLPipeline.__new__(AutoMLPipeline)
+    pipeline.job_name = "child-0"
+    pipeline._cancellation_requested = Mock(return_value=True)
+    pipeline._finish_canceled_launch = Mock(return_value=True)
+    pipeline.create_microservice_action_job = Mock()
+
+    with (
+        patch(f"{ACTIONS_MODULE}.claim_automl_child_launch", return_value=True),
+        patch(
+            f"{ACTIONS_MODULE}.get_automl_child_lifecycle",
+            return_value={"cancel_requested": True, "launch_state": "quiescent"},
+        ),
+    ):
+        assert pipeline.run() is False
+
+    pipeline._finish_canceled_launch.assert_called_once_with(
+        backend_may_exist=False
+    )
+    pipeline.create_microservice_action_job.assert_not_called()
+
+
+def test_automl_pipeline_deletes_resource_when_cancel_races_after_create():
+    """A fence that lands during create is acknowledged only after exact delete."""
+    pipeline = AutoMLPipeline.__new__(AutoMLPipeline)
+    pipeline.job_name = "child-0"
+    pipeline.rec_number = 0
+    pipeline.recs_dict = [{"specs": {}}]
+    pipeline.workspace_metadata = {}
+    pipeline.automl_brain_job_id = "brain-0"
+    pipeline.expt_root = "/results/child-0"
+    pipeline.handler_metadata = {"docker_env_vars": {}}
+    pipeline.job_context = SimpleNamespace(org_name="org", backend_details={})
+    pipeline.add_ptm_dependency = Mock()
+    pipeline.generate_config = Mock(return_value={})
+    pipeline.handle_ptm_anomalies = Mock()
+    pipeline.get_handler_cloud_details = Mock()
+    pipeline.save_recommendation_specs = Mock()
+    pipeline.generate_run_command = Mock(return_value="train")
+    pipeline.detailed_print = Mock()
+    pipeline.decrypt_docker_env_vars = Mock()
+    pipeline.generate_env_variables = Mock()
+    pipeline.generate_nv_job_metadata = Mock()
+    pipeline.create_microservice_action_job = Mock()
+    pipeline.monitor_job = Mock()
+    pipeline._cancellation_requested = Mock(
+        side_effect=[False, False, True]
+    )
+    pipeline._finish_canceled_launch = Mock(return_value=True)
+
+    with (
+        patch(f"{ACTIONS_MODULE}.BACKEND", Backend.LOCAL_DOCKER),
+        patch(f"{ACTIONS_MODULE}.claim_automl_child_launch", return_value=True),
+        patch(
+            f"{ACTIONS_MODULE}.get_automl_child_lifecycle",
+            return_value={"cancel_requested": True, "launch_state": "quiescent"},
+        ),
+        patch(f"{ACTIONS_MODULE}.create_cs_instance", return_value=(Mock(), None)),
+        patch(f"{ACTIONS_MODULE}.wait_for_job_completion"),
+        patch(f"{ACTIONS_MODULE}.delete_lingering_checkpoints"),
+    ):
+        assert pipeline.run() is False
+
+    pipeline.create_microservice_action_job.assert_called_once()
+    pipeline._finish_canceled_launch.assert_called_once_with(
+        backend_may_exist=True
+    )
+    pipeline.monitor_job.assert_not_called()
+
+
+def test_multifidelity_promotion_rearms_quiesced_child_before_enqueue():
+    """A completed child tombstone must not permanently block its next rung."""
+    rec = Recommendation(0, {"train.num_epochs": 1}, "loss")
+    rec.assign_job_id("child-0")
+    rec.update_status(JobStates.success)
+    promoted = ResumeRecommendation(
+        0,
+        {"train.num_epochs": 2},
+        "child-0",
+    )
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="brain-0", early_stop_epoch=1)
+    controller.network = "cosmos-rl"
+    controller.automl_algorithm = "hyperband"
+    controller.automl_algorithm_settings = SimpleNamespace(
+        automl_max_recommendations=4
+    )
+    controller.recommendations = [rec]
+    controller.brain = SimpleNamespace(
+        max_concurrent=1,
+        epoch_number=2,
+        generate_recommendations=Mock(return_value=[promoted]),
+        save_state=Mock(),
+    )
+    controller.best_epoch_number = {0: 1}
+    controller.metric_key = "loss"
+    controller.decrypted_workspace_metadata = {}
+    controller.cs_instance = SimpleNamespace(delete_file=Mock())
+    controller.root = "/nonexistent/automl"
+    controller.hyperband_cancel_condition_seen = False
+    controller.save_state = Mock()
+    controller._inject_automl_env_vars = Mock()
+    controller._get_experiment_results_path = Mock(
+        return_value="/results/child-0"
+    )
+    events = []
+    controller.on_new_automl_job = Mock(
+        side_effect=lambda item: events.append(("enqueue", item.job_id))
+    )
+
+    with (
+        patch(f"{CONTROLLER_MODULE}.report_health_beat"),
+        patch(f"{CONTROLLER_MODULE}.save_automl_current_rec"),
+        patch(f"{CONTROLLER_MODULE}.save_job_specs"),
+        patch(
+            f"{CONTROLLER_MODULE}.get_file_list_from_cloud_storage",
+            return_value=[],
+        ),
+        patch(f"{CONTROLLER_MODULE}.delete_dnn_status"),
+        patch(
+            f"{CONTROLLER_MODULE}.reset_automl_child_lifecycle_for_resume",
+            side_effect=lambda job_id: events.append(("rearm", job_id)) or True,
+        ),
+    ):
+        controller.run_experiments()
+
+    assert events == [("rearm", "child-0"), ("enqueue", "child-0")]
+
+
+def test_child_cancel_resolves_workspace_from_experiment_not_brain():
+    """Remote cancellation uses the child's experiment workspace credentials."""
+    workspace = {"id": "workspace-0", "cloud_type": "slurm", "_id": "mongo-id"}
+    with (
+        patch(
+            f"{AUTOML_JOB_UTILS_MODULE}.get_handler_job_metadata",
+            return_value={"handler_id": "experiment-0", "parent_id": "brain-0"},
+        ),
+        patch(
+            f"{AUTOML_JOB_UTILS_MODULE}.get_handler_metadata",
+            side_effect=[{"workspace": "workspace-0"}, workspace],
+        ),
+        patch(
+            "nvidia_tao_core.microservices.utils.handler_utils."
+            "decrypt_handler_metadata"
+        ),
+        patch.object(
+            ExecutionHandler, "delete_with_handler", return_value=True
+        ) as delete_with_handler,
+    ):
+        assert on_cancel_automl_job("child-0") is True
+
+    delete_with_handler.assert_called_once_with(
+        "child-0",
+        workspace_metadata={"id": "workspace-0", "cloud_type": "slurm"},
+    )
+
+
+def test_automl_stop_orders_fence_and_cleanup_before_brain_delete():
+    """The public stop boundary retains the brain until cleanup is acknowledged."""
+    events = []
+    recommendations = [{"job_id": "child-0", "status": "running"}]
+    termination_handler = Mock()
+    termination_handler.wait_for_job_termination.side_effect = (
+        lambda *args, **kwargs: events.append("brain_wait") or True
+    )
+
+    with (
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.get_automl_controller_info",
+            side_effect=[recommendations, recommendations],
+        ),
+        patch(f"{AUTOML_HANDLER_MODULE}.get_automl_child_job_ids", return_value=[]),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.request_automl_child_cancellation",
+            side_effect=lambda job_id: events.append("intent") or True,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.set_automl_checkpoint_cleanup_state",
+            side_effect=lambda *args, **kwargs: events.append("cleanup_intent") or True,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.cancel_automl_child_job",
+            side_effect=lambda job_id: events.append("child_quiescent") or True,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.get_handler_job_metadata",
+            return_value={
+                "checkpoint_cleanup_pending": False,
+                "checkpoint_cleanup_status": "complete",
+            },
+        ),
+        patch(f"{AUTOML_HANDLER_MODULE}.save_automl_controller_info"),
+        patch(f"{AUTOML_HANDLER_MODULE}.update_automl_details_metadata"),
+        patch.object(
+            ExecutionHandler,
+            "delete_job_with_handler",
+            side_effect=lambda job_id: events.append("brain_delete") or True,
+        ),
+        patch.object(
+            ExecutionHandler,
+            "create_handler",
+            return_value=termination_handler,
+        ),
+        patch(f"{AUTOML_HANDLER_MODULE}.stop_monitoring_job"),
+        patch(f"{AUTOML_HANDLER_MODULE}.BACKEND", Backend.LOCAL_DOCKER),
+    ):
+        response = AutoMLHandler.stop(
+            "user-0", "org", "experiment-0", "brain-0"
+        )
+
+    assert response.code == 200
+    assert events == [
+        "intent",
+        "cleanup_intent",
+        "child_quiescent",
+        "brain_delete",
+        "brain_wait",
+    ]
+
+
+def test_automl_stop_returns_conflict_and_retains_brain_when_barrier_fails():
+    """A failed child barrier is retryable and cannot delete the guardian brain."""
+    recommendations = [{"job_id": "child-0", "status": "running"}]
+    with (
+        patch.dict(os.environ, {"AUTOML_CANCEL_TIMEOUT_SECONDS": "0"}),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.get_automl_controller_info",
+            return_value=recommendations,
+        ),
+        patch(f"{AUTOML_HANDLER_MODULE}.get_automl_child_job_ids", return_value=[]),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.request_automl_child_cancellation",
+            return_value=True,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.set_automl_checkpoint_cleanup_state",
+            return_value=True,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.cancel_automl_child_job",
+            return_value=False,
+        ),
+        patch(
+            f"{AUTOML_HANDLER_MODULE}.get_handler_job_metadata",
+            return_value={"checkpoint_cleanup_pending": True},
+        ),
+        patch(f"{AUTOML_HANDLER_MODULE}.save_automl_controller_info"),
+        patch(f"{AUTOML_HANDLER_MODULE}.update_automl_details_metadata"),
+        patch.object(
+            ExecutionHandler, "delete_job_with_handler"
+        ) as delete_brain,
+    ):
+        response = AutoMLHandler.stop(
+            "user-0", "org", "experiment-0", "brain-0"
+        )
+
+    assert response.code == 409
+    delete_brain.assert_not_called()
+
+
+def test_job_handler_does_not_finalize_parent_when_automl_barrier_is_pending():
+    """The REST-facing handler leaves status Canceling on a retryable conflict."""
+    pending_response = Code(409, [], "cancellation pending")
+    handler_metadata = {
+        "jobs": {"brain-0": {}},
+        "workspace": "workspace-0",
+        "user_id": "user-0",
+    }
+    with (
+        patch(f"{JOB_HANDLER_MODULE}.resolve_metadata", return_value=handler_metadata),
+        patch(f"{JOB_HANDLER_MODULE}.get_handler_metadata", return_value={}),
+        patch(f"{JOB_HANDLER_MODULE}.check_write_access", return_value=True),
+        patch(
+            f"{JOB_HANDLER_MODULE}.get_handler_job_metadata",
+            return_value={"action": "train", "status": "Running"},
+        ),
+        patch(f"{JOB_HANDLER_MODULE}.is_request_automl", return_value=True),
+        patch(f"{JOB_HANDLER_MODULE}.AutoMLHandler.stop", return_value=pending_response),
+        patch(f"{JOB_HANDLER_MODULE}.update_job_status") as update_status,
+        patch(f"{JOB_HANDLER_MODULE}.on_delete_automl_job") as dequeue,
+    ):
+        response = JobHandler.job_cancel(
+            "org", "experiment-0", "brain-0", "experiment"
+        )
+
+    assert response is pending_response
+    assert update_status.call_args_list == [
+        call(
+            "experiment-0",
+            "brain-0",
+            status="Canceling",
+            kind="experiments",
+        )
+    ]
+    dequeue.assert_not_called()

--- a/nvidia_tao_core/tests/microservices/automl/test_controller_checkpoint_cleanup.py
+++ b/nvidia_tao_core/tests/microservices/automl/test_controller_checkpoint_cleanup.py
@@ -1,0 +1,681 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AutoML checkpoint cleanup when the controller is canceled."""
+
+import os
+import shutil
+from types import SimpleNamespace
+from unittest.mock import DEFAULT, MagicMock, Mock, call, patch
+
+
+# Avoid connecting to a real MongoDB instance while importing controller dependencies.
+os.environ["TAO_TEST_MODE"] = "true"
+
+from nvidia_tao_core.microservices.automl.controller import Controller  # noqa: E402
+from nvidia_tao_core.microservices.handlers.execution_handlers.execution_handler import (  # noqa: E402
+    ExecutionHandler,
+)
+from nvidia_tao_core.microservices.utils.automl_utils import JobStates  # noqa: E402
+
+
+CONTROLLER_MODULE = "nvidia_tao_core.microservices.automl.controller"
+
+
+def _recommendation(rec_id, status, result=0.0, job_id=None, resume_from_job_id=None):
+    """Build the recommendation attributes used by cancellation cleanup."""
+    return SimpleNamespace(
+        id=rec_id,
+        status=status,
+        result=result,
+        job_id=job_id or f"job-{rec_id}",
+        resume_from_job_id=resume_from_job_id
+    )
+
+
+def _controller(recommendations, algorithm="bayesian", delete_checkpoints=True, retain_for_resume=False):
+    """Build a controller without invoking external storage initialization."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job", handler_id="experiment")
+    controller.delete_intermediate_ckpt = delete_checkpoints
+    controller.retain_checkpoints_for_resume = retain_for_resume
+    controller.automl_algorithm = algorithm
+    controller.recommendations = recommendations
+    controller.min_max = max
+    controller.refresh_recommendations = Mock()
+    controller._get_experiment_results_path = Mock(
+        side_effect=lambda job_id: f"/results/{job_id}"
+    )
+    controller.delete_checkpoint_files = Mock()
+    controller.delete_not_best_model_checkpoints = Mock()
+    return controller
+
+
+def _start_controller(loop_error=None):
+    """Build the state needed to exercise Controller.start control flow."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job", handler_id="experiment")
+    controller.network = "cosmos-rl"
+    controller.wandb_initialized = False
+    controller.best_model_copied = False
+    controller.best_rec_id = -1
+    controller._checkpoint_cleanup_pending = False
+    controller._initialize_wandb_for_automl = Mock()
+    controller._execute_loop = Mock(side_effect=loop_error)
+    controller.cancel_recommendation_jobs = Mock()
+
+    def persist_cleanup_intent():
+        controller._checkpoint_cleanup_pending = True
+        return True
+
+    controller._schedule_checkpoint_cleanup = Mock(
+        side_effect=persist_cleanup_intent
+    )
+    return controller
+
+
+def _start_dependency_mocks(metadata):
+    """Return a patch.multiple context for Controller.start dependencies."""
+    patcher = patch.multiple(
+        CONTROLLER_MODULE,
+        report_health_beat=DEFAULT,
+        get_job_specs=DEFAULT,
+        update_job_message=DEFAULT,
+        get_handler_job_metadata=DEFAULT,
+        write_job_metadata=DEFAULT,
+        update_job_status=DEFAULT,
+        delete_health_beat=DEFAULT,
+    )
+    mocks = patcher.start()
+    mocks["get_job_specs"].return_value = {}
+    mocks["get_handler_job_metadata"].return_value = metadata
+    return patcher, mocks
+
+
+def test_cancellation_cleanup_honors_delete_intermediate_flag():
+    """Disabling intermediate deletion must leave every recommendation untouched."""
+    controller = _controller(
+        [_recommendation(0, JobStates.canceled)],
+        delete_checkpoints=False
+    )
+
+    assert controller._cleanup_checkpoints_on_cancellation() is True
+
+    controller.refresh_recommendations.assert_not_called()
+    controller.delete_checkpoint_files.assert_not_called()
+    controller.delete_not_best_model_checkpoints.assert_not_called()
+
+
+def test_cancellation_cleanup_preserves_best_and_deletes_non_best_artifacts():
+    """Independent trials retain the best checkpoint and delete other trial artifacts."""
+    best = _recommendation(0, JobStates.success, result=0.9)
+    non_best = _recommendation(1, JobStates.success, result=0.5)
+    canceled = _recommendation(2, JobStates.canceled)
+    failed = _recommendation(3, JobStates.failure)
+    controller = _controller([best, non_best, canceled, failed])
+
+    controller._cleanup_checkpoints_on_cancellation()
+
+    controller.delete_checkpoint_files.assert_called_once_with(
+        "/results/job-0", best, retain_resume_checkpoint=False
+    )
+    assert controller.delete_not_best_model_checkpoints.call_args_list == [
+        call("/results/job-1", non_best, True),
+        call("/results/job-2", canceled, True),
+        call("/results/job-3", failed, True),
+    ]
+
+
+def test_canceled_hyperband_prunes_nonbest_resume_and_promotion_sources():
+    """Terminal cancel prunes nonbest trials; pause is the resumable path."""
+    best = _recommendation(0, JobStates.success, result=0.9)
+    promotion_source = _recommendation(1, JobStates.success, result=0.7)
+    current = _recommendation(2, JobStates.canceled)
+    unused_canceled = _recommendation(3, JobStates.canceled)
+    failed = _recommendation(4, JobStates.failure, resume_from_job_id="job-1")
+    controller = _controller(
+        [best, promotion_source, current, unused_canceled, failed],
+        algorithm="hyperband",
+        retain_for_resume=True,
+    )
+
+    assert controller._cleanup_checkpoints_on_cancellation() is True
+
+    controller.delete_checkpoint_files.assert_called_once_with(
+        "/results/job-0", best, retain_resume_checkpoint=False
+    )
+    assert controller.delete_not_best_model_checkpoints.call_args_list == [
+        call("/results/job-1", promotion_source, True),
+        call("/results/job-2", current, True),
+        call("/results/job-3", unused_canceled, True),
+        call("/results/job-4", failed, True),
+    ]
+
+
+def test_cancellation_cleanup_continues_after_storage_error():
+    """A failure deleting one trial must not prevent cleanup of later trials."""
+    first = _recommendation(0, JobStates.canceled)
+    second = _recommendation(1, JobStates.failure)
+    controller = _controller([first, second])
+    controller.delete_not_best_model_checkpoints.side_effect = [
+        RuntimeError("storage unavailable"),
+        None
+    ]
+
+    assert controller._cleanup_checkpoints_on_cancellation() is False
+
+    assert controller.delete_not_best_model_checkpoints.call_args_list == [
+        call("/results/job-0", first, True),
+        call("/results/job-1", second, True),
+    ]
+
+
+def test_cancellation_cleanup_retries_when_best_pruning_is_unverified():
+    """A silent/partial storage delete must keep the durable cleanup pending."""
+    best = _recommendation(0, JobStates.success, result=0.9)
+    controller = _controller([best])
+    controller.delete_checkpoint_files.return_value = False
+
+    assert controller._cleanup_checkpoints_on_cancellation() is False
+
+
+def test_nonbest_cleanup_detects_acknowledged_but_still_visible_artifact():
+    """Deletion acknowledgement alone is not proof that a remote prefix is gone."""
+    rec = _recommendation(0, JobStates.failure)
+    controller = Controller.__new__(Controller)
+    controller.recommendations = [rec]
+    controller.min_max = max
+    controller.decrypted_workspace_metadata = {}
+    controller._uses_folder_lookup = Mock(return_value=False)
+    controller.cs_instance = SimpleNamespace(
+        is_file=Mock(return_value=True),
+        delete_file=Mock(return_value=True),
+    )
+    checkpoint = "/results/job-0/model.pth"
+
+    with patch(
+        f"{CONTROLLER_MODULE}.get_file_list_from_cloud_storage",
+        side_effect=[[checkpoint], [checkpoint]],
+    ):
+        controller.delete_not_best_model_checkpoints(
+            "/results/job-0", rec, True
+        )
+
+    assert controller._last_checkpoint_delete_verified is False
+
+
+def test_multifidelity_trial_retains_best_and_rung_boundary_checkpoint():
+    """Promotion needs the rung checkpoint even when an earlier epoch scored best."""
+    best_path = "/results/job-0/model_epoch_1.pth"
+    intermediate_path = "/results/job-0/model_epoch_2.pth"
+    resume_path = "/results/job-0/model_epoch_3.pth"
+    remaining = {best_path, intermediate_path, resume_path}
+
+    class Storage:
+        @staticmethod
+        def is_file(path):
+            return path in remaining
+
+        @staticmethod
+        def delete_file(path):
+            remaining.discard(path)
+            return True
+
+    rec = _recommendation(0, JobStates.success, result=0.9)
+    rec.early_stop_epoch = 3
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job")
+    controller.automl_algorithm = "hyperband"
+    controller.retain_checkpoints_for_resume = True
+    controller.decrypted_workspace_metadata = {}
+    controller.cs_instance = Storage()
+    controller.ckpt_path = {}
+    controller._uses_folder_lookup = Mock(return_value=False)
+    controller.get_best_checkpoint_path = Mock(
+        side_effect=lambda path, item, filter_by_format=False: controller.ckpt_path.update(
+            {path: {"pth": best_path}}
+        )
+    )
+    controller.get_checkpoint_paths_matching_epoch_number = Mock(
+        return_value=([], [], [resume_path], [], [])
+    )
+
+    with (
+        patch.dict(os.environ, {"CI_PROJECT_DIR": "test"}),
+        patch(
+            f"{CONTROLLER_MODULE}.get_file_list_from_cloud_storage",
+            side_effect=lambda *_args, **_kwargs: sorted(remaining),
+        ),
+        patch(f"{CONTROLLER_MODULE}.report_health_beat"),
+    ):
+        assert controller.delete_checkpoint_files(
+            "/results/job-0", rec, retain_resume_checkpoint=True
+        ) is True
+
+    assert remaining == {best_path, resume_path}
+    controller.get_checkpoint_paths_matching_epoch_number.assert_called_once_with(
+        "/results/job-0", 0, epoch_number=3
+    )
+
+
+@patch("nvidia_tao_core.microservices.automl.controller.get_automl_controller_info", return_value=[])
+@patch(
+    "nvidia_tao_core.microservices.automl.controller."
+    "set_automl_checkpoint_cleanup_state",
+    new=Mock(return_value=True),
+)
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.get_handler_job_metadata",
+    return_value={"status": "canceling"}
+)
+@patch("nvidia_tao_core.microservices.automl.controller.report_health_beat")
+@patch("nvidia_tao_core.microservices.automl.controller.update_job_status")
+def test_execute_loop_schedules_checkpoint_cleanup_on_cancellation_exit(
+    mock_update_status, mock_health_beat, mock_job_metadata, mock_controller_info
+):
+    """The cancellation status must not bypass eligible checkpoint cleanup."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job", handler_id="experiment")
+    controller.completed_recommendations = 0
+    controller.automl_algorithm_settings = SimpleNamespace(automl_max_recommendations=4)
+    controller._checkpoint_cleanup_pending = False
+
+    assert controller._execute_loop() is None
+
+    assert controller._checkpoint_cleanup_pending is True
+    mock_job_metadata.assert_called_once_with("automl-job")
+    mock_controller_info.assert_called_once_with("automl-job")
+    assert mock_health_beat.call_count == 2
+    mock_update_status.assert_called_once()
+
+
+@patch(
+    "nvidia_tao_core.microservices.automl.controller."
+    "set_automl_checkpoint_cleanup_state",
+    return_value=True,
+)
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.get_automl_child_job_ids",
+    return_value=[],
+)
+@patch("nvidia_tao_core.microservices.automl.controller.on_delete_automl_job")
+@patch("nvidia_tao_core.microservices.automl.controller.cancel_automl_child_job")
+def test_cancel_jobs_cleans_checkpoints_after_stopping_children(
+    mock_cancel_job, mock_delete_job, mock_child_ids, mock_cleanup_state
+):
+    """Deferred cleanup runs after child cancellation and before deleting the parent."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job")
+    controller.recommendations = [_recommendation(0, JobStates.canceled)]
+    controller._checkpoint_cleanup_pending = True
+    controller._cleanup_checkpoints_on_cancellation = Mock()
+
+    events = []
+    mock_cancel_job.side_effect = lambda job_id: events.append(("cancel", job_id)) or True
+    controller._cleanup_checkpoints_on_cancellation.side_effect = (
+        lambda: events.append(("cleanup", None)) or True
+    )
+    mock_delete_job.side_effect = lambda job_id: events.append(("delete", job_id))
+
+    with patch.dict(os.environ, {"TAO_EXECUTION_BACKEND": "remote"}, clear=True):
+        controller.cancel_recommendation_jobs()
+
+    assert events == [
+        ("cancel", "job-0"),
+        ("cleanup", None),
+        ("delete", "automl-job"),
+    ]
+    assert controller._checkpoint_cleanup_pending is False
+
+
+@patch(
+    "nvidia_tao_core.microservices.automl.controller."
+    "set_automl_checkpoint_cleanup_state",
+    return_value=True,
+)
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.get_automl_child_job_ids",
+    return_value=[],
+)
+@patch("nvidia_tao_core.microservices.automl.controller.on_delete_automl_job")
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.cancel_automl_child_job",
+    return_value=False,
+)
+def test_cancel_jobs_retains_checkpoints_when_writer_stop_is_unconfirmed(
+    mock_cancel_job, mock_delete_job, mock_child_ids, mock_cleanup_state
+):
+    """A failed cancellation barrier must never be followed by storage deletion."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job")
+    controller.recommendations = [_recommendation(0, JobStates.canceled)]
+    controller._checkpoint_cleanup_pending = True
+    controller._cleanup_checkpoints_on_cancellation = Mock()
+
+    with patch.dict(os.environ, {"TAO_EXECUTION_BACKEND": "remote"}, clear=True):
+        assert controller.cancel_recommendation_jobs() is False
+
+    controller._cleanup_checkpoints_on_cancellation.assert_not_called()
+    assert controller._checkpoint_cleanup_pending is True
+    mock_cancel_job.assert_called_once_with("job-0")
+    mock_delete_job.assert_not_called()
+
+
+def test_pending_cleanup_retries_after_a_false_barrier():
+    """The guardian controller retries instead of treating False as completion."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job")
+    controller.cancel_recommendation_jobs = Mock(side_effect=[False, True])
+
+    with (
+        patch(f"{CONTROLLER_MODULE}.report_health_beat") as report_health_beat,
+        patch(f"{CONTROLLER_MODULE}.time.sleep") as sleep,
+    ):
+        assert controller._finish_pending_checkpoint_cleanup() is True
+
+    assert controller.cancel_recommendation_jobs.call_count == 2
+    report_health_beat.assert_called_once()
+    sleep.assert_called_once_with(5)
+
+
+@patch(
+    "nvidia_tao_core.microservices.automl.controller."
+    "set_automl_checkpoint_cleanup_state",
+    return_value=True,
+)
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.get_automl_child_job_ids",
+    return_value=[],
+)
+@patch("nvidia_tao_core.microservices.automl.controller.on_delete_automl_job")
+@patch(
+    "nvidia_tao_core.microservices.automl.controller.cancel_automl_child_job",
+    return_value=True,
+)
+def test_artifact_failure_remains_durably_pending(
+    mock_cancel_job, mock_delete_job, mock_child_ids, mock_cleanup_state
+):
+    """A partial storage failure blocks parent deletion and remains retryable."""
+    controller = Controller.__new__(Controller)
+    controller.automl_context = SimpleNamespace(id="automl-job")
+    controller.recommendations = [_recommendation(0, JobStates.canceled)]
+    controller._checkpoint_cleanup_pending = True
+    controller._cleanup_checkpoints_on_cancellation = Mock(return_value=False)
+
+    with patch.dict(os.environ, {"TAO_EXECUTION_BACKEND": "remote"}, clear=True):
+        assert controller.cancel_recommendation_jobs() is False
+
+    assert controller._checkpoint_cleanup_pending is True
+    mock_delete_job.assert_not_called()
+    assert call(
+        "automl-job",
+        "pending",
+        error="one or more checkpoint artifacts could not be removed",
+    ) in mock_cleanup_state.call_args_list
+
+
+def test_delete_with_handler_propagates_explicit_cancellation_failure():
+    """The controller must be able to distinguish acceptance from failure."""
+    handler = Mock()
+    handler.delete.return_value = False
+    with patch.object(ExecutionHandler, "create_handler", return_value=handler):
+        assert not ExecutionHandler.delete_with_handler("job-0", {})
+
+
+def test_kubernetes_delete_waits_until_child_pods_are_gone():
+    """Foreground deletion is complete only after every writer pod exits."""
+    from nvidia_tao_core.microservices.handlers.execution_handlers.kubernetes_handler import (  # noqa: E501
+        KubernetesHandler,
+    )
+
+    handler = KubernetesHandler.__new__(KubernetesHandler)
+    handler.logger = Mock()
+    handler.delete_statefulset = Mock(return_value=True)
+    handler.get_namespace = Mock(return_value="default")
+    core_api = MagicMock()
+    core_api.list_namespaced_pod.side_effect = [
+        SimpleNamespace(items=[object()]),
+        SimpleNamespace(items=[]),
+    ]
+    with (
+        patch(
+            "nvidia_tao_core.microservices.handlers.execution_handlers."
+            "kubernetes_handler.client.CoreV1Api",
+            return_value=core_api,
+        ),
+        patch(
+            "nvidia_tao_core.microservices.handlers.execution_handlers."
+            "kubernetes_handler.time.sleep"
+        ),
+    ):
+        assert handler.delete("job-0")
+
+    assert core_api.list_namespaced_pod.call_count == 2
+
+
+def test_slurm_cancel_waits_for_terminal_scheduler_state():
+    """Successful scancel submission alone is not a writer-stop barrier."""
+    from nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler import (  # noqa: E501
+        SlurmHandler,
+    )
+
+    handler = SlurmHandler.__new__(SlurmHandler)
+    handler.logger = Mock()
+    handler.get_automl_aware_handler_params = Mock(
+        return_value={"brain_job_id": "brain-0"}
+    )
+    handler.get_slurm_job_id = Mock(return_value="42")
+    handler.get_slurm_job_status = Mock(
+        side_effect=["RUNNING", "RUNNING", "CANCELLED"]
+    )
+    handler._build_ssh_command = Mock(return_value=["scancel", "42"])
+    handler.update_job_status = Mock()
+    completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+    module = (
+        "nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler"
+    )
+    with (
+        patch(f"{module}.get_handler_job_metadata", return_value={"id": "brain-0"}),
+        patch(f"{module}.subprocess.run", return_value=completed),
+        patch(f"{module}.time.sleep"),
+    ):
+        assert handler.cancel_job("job-0")
+
+    assert handler.get_slurm_job_status.call_count == 3
+
+
+def test_slurm_cancel_without_metadata_is_already_quiescent():
+    """A job that was never submitted has no SLURM writer to stop."""
+    from nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler import (  # noqa: E501
+        SlurmHandler,
+    )
+
+    handler = SlurmHandler.__new__(SlurmHandler)
+    handler.logger = Mock()
+    handler.get_automl_aware_handler_params = Mock(
+        return_value={"brain_job_id": "brain-0"}
+    )
+    handler.get_slurm_job_id = Mock()
+    module = (
+        "nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler"
+    )
+
+    with patch(f"{module}.get_handler_job_metadata", return_value=None):
+        assert handler.cancel_job("job-0") is True
+
+    handler.get_slurm_job_id.assert_not_called()
+
+
+def test_slurm_cancel_without_scheduler_id_is_already_quiescent():
+    """Metadata without a scheduler ID means there is no submitted job to cancel."""
+    from nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler import (  # noqa: E501
+        SlurmHandler,
+    )
+
+    handler = SlurmHandler.__new__(SlurmHandler)
+    handler.logger = Mock()
+    handler.get_automl_aware_handler_params = Mock(
+        return_value={"brain_job_id": "brain-0"}
+    )
+    handler.get_slurm_job_id = Mock(return_value=None)
+    handler.get_slurm_job_status = Mock()
+    module = (
+        "nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler"
+    )
+
+    with patch(
+        f"{module}.get_handler_job_metadata", return_value={"id": "brain-0"}
+    ):
+        assert handler.cancel_job("job-0") is True
+
+    handler.get_slurm_job_status.assert_not_called()
+
+
+def test_slurm_cancel_fails_closed_when_scheduler_query_fails():
+    """An unconfirmed scheduler state must not release the cleanup barrier."""
+    from nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler import (  # noqa: E501
+        SlurmHandler,
+    )
+
+    handler = SlurmHandler.__new__(SlurmHandler)
+    handler.logger = Mock()
+    handler.get_automl_aware_handler_params = Mock(
+        return_value={"brain_job_id": "brain-0"}
+    )
+    handler.get_slurm_job_id = Mock(return_value="42")
+    handler.get_slurm_job_status = Mock(return_value="ERROR")
+    handler._build_ssh_command = Mock()
+    module = (
+        "nvidia_tao_core.microservices.handlers.execution_handlers.slurm_handler"
+    )
+
+    with patch(
+        f"{module}.get_handler_job_metadata", return_value={"id": "brain-0"}
+    ):
+        assert handler.cancel_job("job-0") is False
+
+    handler._build_ssh_command.assert_not_called()
+
+
+def test_start_preserves_canceled_parent_status_and_runs_deferred_cleanup():
+    """A handled cancellation must not fall through to Error/Done finalization."""
+    controller = _start_controller()
+    controller._execute_loop.side_effect = lambda: setattr(
+        controller, "_checkpoint_cleanup_pending", True
+    )
+    cleanup_pending_at_cancel = []
+    controller.cancel_recommendation_jobs.side_effect = lambda: cleanup_pending_at_cancel.append(
+        controller._checkpoint_cleanup_pending
+    )
+    patcher, mocks = _start_dependency_mocks({"status": "Canceled", "job_details": {}})
+    try:
+        controller.start()
+    finally:
+        patcher.stop()
+
+    assert cleanup_pending_at_cancel == [True]
+    controller.cancel_recommendation_jobs.assert_called_once_with()
+    mocks["write_job_metadata"].assert_not_called()
+    mocks["update_job_status"].assert_not_called()
+    mocks["delete_health_beat"].assert_called_once_with("automl-job")
+
+
+def test_successful_completion_schedules_durable_final_trial_pruning():
+    """ASHA/non-incremental leftovers are pruned through the terminal barrier."""
+    controller = _start_controller()
+    controller.automl_algorithm = "asha"
+    controller.best_model_copied = True
+    controller._get_experiment_results_path = Mock(return_value="/results/automl-job")
+    events = []
+    controller._schedule_checkpoint_cleanup = Mock(
+        side_effect=lambda: events.append("cleanup_pending") or True
+    )
+    controller._finish_pending_checkpoint_cleanup = Mock(
+        side_effect=lambda: events.append("cleanup_complete") or True
+    )
+    metadata = {"status": "Running", "job_details": {}}
+    patcher, mocks = _start_dependency_mocks(metadata)
+    try:
+        controller.start()
+    finally:
+        patcher.stop()
+
+    assert events == ["cleanup_pending", "cleanup_complete"]
+    mocks["update_job_status"].assert_called_once_with(
+        "experiment", "automl-job", status="Done", kind="experiments"
+    )
+    mocks["delete_health_beat"].assert_called_once_with("automl-job")
+
+
+def test_start_exception_schedules_cleanup_before_stopping_children():
+    """Abnormal exits schedule eligible cleanup before child teardown."""
+    controller = _start_controller(loop_error=RuntimeError("training interrupted"))
+    cleanup_pending_at_cancel = []
+    controller.cancel_recommendation_jobs.side_effect = lambda: cleanup_pending_at_cancel.append(
+        controller._checkpoint_cleanup_pending
+    )
+    metadata = {"status": "Running", "job_details": {}}
+    patcher, mocks = _start_dependency_mocks(metadata)
+    try:
+        controller.start()
+    finally:
+        patcher.stop()
+
+    assert cleanup_pending_at_cancel == [True]
+    mocks["write_job_metadata"].assert_called_once_with("automl-job", metadata)
+    mocks["update_job_status"].assert_called_once_with(
+        "experiment", "automl-job", status="Error", kind="experiments"
+    )
+    mocks["delete_health_beat"].assert_called_once_with("automl-job")
+
+
+def test_start_exception_does_not_overwrite_cancellation_status():
+    """An exception racing with cancellation must leave parent status externally managed."""
+    controller = _start_controller(loop_error=RuntimeError("controller interrupted"))
+    patcher, mocks = _start_dependency_mocks({"status": "canceling", "job_details": {}})
+    try:
+        controller.start()
+    finally:
+        patcher.stop()
+
+    controller.cancel_recommendation_jobs.assert_called_once_with()
+    mocks["write_job_metadata"].assert_not_called()
+    mocks["update_job_status"].assert_not_called()
+
+
+def test_folder_checkpoint_cleanup_removes_cosmos_sidecars(tmp_path):
+    """Deleting a Cosmos checkpoint leaf also removes extensionless sidecar files."""
+    policy_folder = tmp_path / "train_output" / "checkpoints" / "epoch_1" / "policy"
+    policy_folder.mkdir(parents=True)
+    for name in (
+        "model_rank_0.pth",
+        "optimizer_rank_0.pth",
+        ".rank_0_complete",
+        "cosmos_config",
+    ):
+        (policy_folder / name).write_text("checkpoint data", encoding="utf-8")
+    unrelated_file = tmp_path / "microservices_log.txt"
+    unrelated_file.write_text("keep", encoding="utf-8")
+
+    class LocalStorage:
+        """Minimal recursive-delete storage adapter for the folder cleanup test."""
+
+        @staticmethod
+        def delete_folder(folder):
+            shutil.rmtree(folder)
+
+    rec = _recommendation(0, JobStates.canceled)
+    controller = Controller.__new__(Controller)
+    controller.recommendations = [rec]
+    controller.min_max = max
+    controller.decrypted_workspace_metadata = {}
+    controller.cs_instance = LocalStorage()
+    controller._uses_folder_lookup = Mock(return_value=True)
+    listed_files = [str(file_path) for file_path in tmp_path.rglob("*") if file_path.is_file()]
+
+    with patch(f"{CONTROLLER_MODULE}.get_file_list_from_cloud_storage", return_value=listed_files):
+        controller.delete_not_best_model_checkpoints(str(tmp_path), rec, True)
+
+    assert not policy_folder.exists()
+    assert policy_folder.parent.exists()  # Empty structural ancestors are intentionally retained.
+    assert unrelated_file.exists()

--- a/nvidia_tao_core/tests/microservices/handlers/test_docker_output_ownership.py
+++ b/nvidia_tao_core/tests/microservices/handlers/test_docker_output_ownership.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ownership safety tests for TAO Core's local Docker backend."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from nvidia_tao_core.microservices.enum_constants import Backend
+from nvidia_tao_core.microservices.handlers.execution_handlers.docker_handler import (
+    DockerHandler,
+    _configured_container_identity,
+    _writable_bind_mounts,
+)
+from nvidia_tao_core.microservices.handlers.execution_handlers.execution_handler import (
+    ExecutionHandler,
+)
+
+
+def _handler():
+    handler = object.__new__(DockerHandler)
+    ExecutionHandler.__init__(handler, backend_type=Backend.LOCAL_DOCKER)
+    handler._docker_image = "nvcr.io/nvidia/tao/example:test"
+    handler._docker_client = MagicMock()
+    handler._docker_client.info.return_value = {"SecurityOptions": []}
+    handler._api_client = MagicMock()
+    handler._container = None
+    return handler
+
+
+def test_writable_bind_detection_skips_read_only_and_docker_socket():
+    assert _writable_bind_mounts(["/data"]) == []
+    assert _writable_bind_mounts([
+        "/host/results:/results",
+        "/host/data:/data:ro",
+        "/var/run/docker.sock:/var/run/docker.sock",
+    ]) == [("/host/results", "/results", "rw")]
+    assert _writable_bind_mounts({
+        "/host/results": {"bind": "/results", "mode": "rw,z"},
+        "/host/data": {"bind": "/data", "mode": "ro"},
+    }) == [("/host/results", "/results", "rw,z")]
+    assert _writable_bind_mounts({
+        "/host/data": {"bind": "/data", "ro": True},
+        "/host/results": {
+            "bind": "/results",
+            "ro": False,
+            "propagation": "rshared",
+        },
+    }) == [("/host/results", "/results", "rw,rshared")]
+    # Ownership discovery must not add restrictions to mounts that cannot
+    # create host output.
+    assert _writable_bind_mounts(["/host/root:/:ro"]) == []
+    with pytest.raises(ValueError, match='both "ro" and "mode"'):
+        _writable_bind_mounts({
+            "/host/results": {"bind": "/results", "ro": False, "mode": "rw"}
+        })
+
+
+@pytest.mark.parametrize("value", ["", "root", "0:0", "0:1000", "1000", "a:b"])
+def test_writable_bind_identity_requires_explicit_non_root_uid_gid(monkeypatch, value):
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", value)
+    with pytest.raises(RuntimeError, match="verified non-root"):
+        _configured_container_identity()
+
+
+def test_explicit_identity_and_supplementary_groups_are_numeric(monkeypatch):
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", "1234:5678")
+    monkeypatch.setenv("TAO_DOCKER_GROUP_ADD", "5678, 99,100,99")
+    assert _configured_container_identity() == ("1234:5678", ["99", "100"])
+
+    monkeypatch.setenv("TAO_DOCKER_GROUP_ADD", "99,developers")
+    with pytest.raises(RuntimeError, match="numeric supplementary"):
+        _configured_container_identity()
+
+
+def test_bind_preflight_uses_exact_identity_and_prepares_runtime_home():
+    handler = _handler()
+
+    handler._preflight_writable_bind(
+        "/host/results", "rw,z", "1234:5678", ["99"], prepare_home=True
+    )
+
+    kwargs = handler._docker_client.containers.run.call_args.kwargs
+    assert kwargs["user"] == "1234:5678"
+    assert kwargs["group_add"] == ["99"]
+    assert kwargs["volumes"] == {
+        "/host/results": {"bind": "/ownership-probe", "mode": "rw,z"}
+    }
+    assert kwargs["remove"] is True
+    assert "mkdir \"$probe\"" in kwargs["command"][1]
+    assert 'test ! -L "$path"' in kwargs["command"][1]
+    assert "chmod 700" in kwargs["command"][1]
+    assert '"$cache/huggingface"' in kwargs["command"][1]
+
+
+def test_bind_preflight_supports_writable_file_bind_without_using_it_as_home():
+    handler = _handler()
+
+    handler._preflight_writable_bind(
+        "/host/config.yaml", "rw", "1234:5678", [], prepare_home=False
+    )
+
+    script = handler._docker_client.containers.run.call_args.kwargs["command"][1]
+    assert "elif [ -f /ownership-probe ]" in script
+    assert "test -w /ownership-probe" in script
+
+
+def test_bind_preflight_failure_blocks_workload_launch():
+    handler = _handler()
+    handler._docker_client.containers.run.side_effect = RuntimeError("permission denied")
+
+    with pytest.raises(PermissionError, match="could not create and delete"):
+        handler._preflight_writable_bind(
+            "/host/results", "rw", "1234:5678", [], prepare_home=True
+        )
+
+
+def test_rootless_or_userns_daemon_is_rejected(monkeypatch):
+    handler = _handler()
+    handler._docker_client.info.return_value = {
+        "SecurityOptions": ["name=seccomp,profile=builtin", "name=rootless"]
+    }
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", "1234:5678")
+
+    with pytest.raises(RuntimeError, match="rootless or userns-remapped"):
+        handler._prepare_writable_bind_runtime(["/host/results:/results"])
+
+    handler._docker_client.containers.run.assert_not_called()
+
+
+def test_bind_runtime_prefers_results_for_home_and_checks_each_source(monkeypatch):
+    handler = _handler()
+    handler._preflight_writable_bind = MagicMock()
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", "1234:5678")
+    monkeypatch.setenv("TAO_DOCKER_GROUP_ADD", "99")
+
+    user, groups, environment = handler._prepare_writable_bind_runtime({
+        "/host/scratch": {"bind": "/scratch", "mode": "rw"},
+        "/host/results": {"bind": "/results", "mode": "rw"},
+    })
+
+    assert user == "1234:5678"
+    assert groups == ["99"]
+    assert environment["HOME"] == "/results/.tao-runtime/home"
+    assert environment["USER"] == "1234"
+    assert environment["LOGNAME"] == "1234"
+    assert environment["HF_HOME"] == "/results/.tao-runtime/home/.cache/huggingface"
+    assert handler._preflight_writable_bind.call_args_list == [
+        call(
+            "/host/scratch", "rw", "1234:5678", ["99"], prepare_home=False
+        ),
+        call(
+            "/host/results", "rw", "1234:5678", ["99"], prepare_home=True
+        ),
+    ]
+
+
+def test_start_container_maps_verified_user_and_writable_home(monkeypatch):
+    handler = _handler()
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", "1234:5678")
+    monkeypatch.setenv("TAO_DOCKER_GROUP_ADD", "99")
+    launched = SimpleNamespace(name="job-1")
+    handler._docker_client.containers.get.side_effect = RuntimeError("not found")
+    handler._docker_client.containers.run.return_value = launched
+    handler._check_image_exists = MagicMock(return_value=True)
+    handler.update_image_pull_status = MagicMock()
+    handler.get_device_requests = MagicMock(return_value=[])
+    handler._prepare_writable_bind_runtime = MagicMock(return_value=(
+        "1234:5678",
+        ["99"],
+        {
+            "HOME": "/results/.tao-runtime/home",
+            "USER": "1234",
+            "LOGNAME": "1234",
+            "XDG_CACHE_HOME": "/results/.tao-runtime/home/.cache",
+        },
+    ))
+
+    with patch(
+        "nvidia_tao_core.microservices.handlers.execution_handlers.docker_handler."
+        "should_use_nvidia_runtime",
+        return_value=False,
+    ), patch(
+        "nvidia_tao_core.microservices.handlers.execution_handlers.docker_handler."
+        "get_handler_job_metadata",
+        return_value={},
+    ):
+        handler.start_container(
+            container_name="job-1",
+            docker_env_vars={"HOME": "/root", "KEEP": "yes"},
+            command=["train"],
+            num_gpus=0,
+            volumes=["/host/results:/results"],
+        )
+
+    kwargs = handler._docker_client.containers.run.call_args.kwargs
+    assert kwargs["user"] == "1234:5678"
+    assert kwargs["group_add"] == ["99"]
+    assert kwargs["environment"]["HOME"] == "/results/.tao-runtime/home"
+    assert kwargs["environment"]["USER"] == "1234"
+    assert kwargs["environment"]["LOGNAME"] == "1234"
+    assert kwargs["environment"]["XDG_CACHE_HOME"].endswith("/.cache")
+    assert kwargs["environment"]["KEEP"] == "yes"
+    handler._prepare_writable_bind_runtime.assert_called_once_with(
+        ["/host/results:/results"],
+        writable_mounts=[("/host/results", "/results", "rw")],
+        configured_identity=("1234:5678", ["99"]),
+        identity_mapping_verified=True,
+    )
+
+
+def test_start_container_without_writable_bind_preserves_image_user():
+    handler = _handler()
+    assert handler._prepare_writable_bind_runtime([
+        "/host/data:/data:ro",
+        "/var/run/docker.sock:/var/run/docker.sock",
+    ]) is None
+    assert handler._prepare_writable_bind_runtime([
+        "/host/config.yaml:/config.yaml",
+    ]) is None
+
+
+def test_start_container_rejects_missing_identity_before_image_check(monkeypatch):
+    handler = _handler()
+    handler._check_image_exists = MagicMock()
+    monkeypatch.delenv("TAO_DOCKER_CONTAINER_USER", raising=False)
+
+    with pytest.raises(RuntimeError, match="verified non-root"):
+        handler.start_container(
+            container_name="job-1",
+            num_gpus=0,
+            volumes=["/host/results:/results"],
+        )
+
+    handler._check_image_exists.assert_not_called()
+    handler._docker_client.containers.run.assert_not_called()
+
+
+def test_start_container_preflight_failure_never_launches_workload(monkeypatch):
+    handler = _handler()
+    handler._check_image_exists = MagicMock(return_value=True)
+    handler.update_image_pull_status = MagicMock()
+    handler.get_device_requests = MagicMock()
+    handler._docker_client.containers.run.side_effect = RuntimeError("permission denied")
+    monkeypatch.setenv("TAO_DOCKER_CONTAINER_USER", "1234:5678")
+
+    with pytest.raises(PermissionError, match="could not create and delete"):
+        handler.start_container(
+            container_name="job-1",
+            num_gpus=0,
+            volumes=["/host/results:/results"],
+        )
+
+    assert handler._docker_client.containers.run.call_count == 1
+    handler.get_device_requests.assert_not_called()
+    assert handler._container is None
+
+
+def test_full_start_with_anonymous_and_file_volumes_preserves_image_user():
+    handler = _handler()
+    handler._check_image_exists = MagicMock(return_value=True)
+    handler.update_image_pull_status = MagicMock()
+    handler.get_device_requests = MagicMock(return_value=[])
+    handler._docker_client.containers.get.side_effect = RuntimeError("not found")
+    handler._docker_client.containers.run.return_value = SimpleNamespace(name="job-1")
+
+    with patch(
+        "nvidia_tao_core.microservices.handlers.execution_handlers.docker_handler."
+        "should_use_nvidia_runtime",
+        return_value=False,
+    ), patch(
+        "nvidia_tao_core.microservices.handlers.execution_handlers.docker_handler."
+        "get_handler_job_metadata",
+        return_value={},
+    ):
+        handler.start_container(
+            container_name="job-1",
+            num_gpus=0,
+            volumes=["/data", "/host/config.yaml:/config.yaml"],
+        )
+
+    kwargs = handler._docker_client.containers.run.call_args.kwargs
+    assert "user" not in kwargs
+    assert "group_add" not in kwargs
+    assert kwargs["volumes"] == ["/data", "/host/config.yaml:/config.yaml"]

--- a/nvidia_tao_core/tests/microservices/utils/test_slurm_cloud_storage_cleanup.py
+++ b/nvidia_tao_core/tests/microservices/utils/test_slurm_cloud_storage_cleanup.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Failure propagation tests for checkpoint deletion over Slurm SSH."""
+
+import pytest
+
+from nvidia_tao_core.microservices.utils.slurm_cloud_storage import (
+    SlurmCloudStorageAdapter,
+)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "remote_path"),
+    (("delete_folder", "trial/checkpoints"), ("delete_file", "trial/model.pth")),
+)
+def test_slurm_checkpoint_delete_propagates_remote_rm_failure(
+    method_name, remote_path
+):
+    """Controller cleanup must see a failed remote rm as an exception."""
+    adapter = SlurmCloudStorageAdapter.__new__(SlurmCloudStorageAdapter)
+    adapter._get_full_path = lambda path: f"/results/{path}"
+    adapter._run_ssh_command = lambda command: (
+        False,
+        "",
+        "Permission denied",
+    )
+
+    undecorated_method = getattr(
+        SlurmCloudStorageAdapter, method_name
+    ).__wrapped__
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        undecorated_method(adapter, remote_path)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "remote_path"),
+    (("delete_folder", "trial/checkpoints"), ("delete_file", "trial/model.pth")),
+)
+def test_slurm_checkpoint_delete_acknowledges_success(method_name, remote_path):
+    """A zero-status remote rm provides an explicit cleanup acknowledgement."""
+    adapter = SlurmCloudStorageAdapter.__new__(SlurmCloudStorageAdapter)
+    adapter._get_full_path = lambda path: f"/results/{path}"
+    adapter._run_ssh_command = lambda command: (True, "", "")
+
+    undecorated_method = getattr(
+        SlurmCloudStorageAdapter, method_name
+    ).__wrapped__
+    assert undecorated_method(adapter, remote_path) is True

--- a/nvidia_tao_core/tests/scripts/test_generate_schema.py
+++ b/nvidia_tao_core/tests/scripts/test_generate_schema.py
@@ -8,9 +8,12 @@ import os
 import pathlib
 import pytest
 
+from omegaconf import OmegaConf
+
 from nvidia_tao_core.microservices.constants import TAO_NETWORKS
 from nvidia_tao_core.microservices.enum_constants import _get_network_architectures
 from nvidia_tao_core.microservices.utils.core_utils import get_microservices_network_and_action
+from nvidia_tao_core.config.clip.default_config import CLIPValDataConfig
 from nvidia_tao_core.scripts.generate_schema import generate_schema
 
 EXCLUDED_KEYWORDS = [
@@ -87,3 +90,92 @@ def test_networks_with_valid_actions(network, action):
     assert isinstance(schema, dict)
     assert "properties" in schema
     assert "default" in schema
+
+
+def test_clip_train_metadata_masking_schema():
+    """CLIP train schema exposes metadata-masked SigLIP configuration."""
+    schema = generate_schema("clip", "train")
+
+    train_dataset = schema["properties"]["dataset"]["properties"]["train"]
+    train_dataset_default = schema["default"]["dataset"]["train"]
+    train = schema["properties"]["train"]
+    train_default = schema["default"]["train"]
+
+    include_metadata = train_dataset["properties"]["include_attribute_metadata"]
+    assert include_metadata["type"] == "bool"
+    assert include_metadata["default"] is False
+    assert train_dataset_default["include_attribute_metadata"] is False
+
+    dist_impl = train["properties"]["siglip_loss_dist_impl"]
+    assert dist_impl["default"] == "gather"
+    assert dist_impl["enum"] == ["bidir", "shift", "reduce", "gather", "local"]
+    assert train_default["siglip_loss_dist_impl"] == "gather"
+    assert "Metadata masking supports local and gather." in dist_impl["description"]
+
+    mask_mode = train["properties"]["siglip_loss_mask_mode"]
+    assert mask_mode["default"] == "none"
+    assert mask_mode["enum"] == [
+        "none",
+        "attribute_match_ignore",
+        "attribute_plus_accessory_match_ignore",
+    ]
+    assert train_default["siglip_loss_mask_mode"] == "none"
+    assert "Metadata masking supports local and gather." in mask_mode["description"]
+    assert "train.siglip_loss_dist_impl to be 'local' or 'gather'" in mask_mode["description"]
+
+
+def test_clip_metadata_evaluation_schema():
+    """CLIP schemas expose metadata-aware validation and evaluation options."""
+    schema = generate_schema("clip", "evaluate")
+    inference_schema = generate_schema("clip", "inference")
+
+    val = schema["properties"]["dataset"]["properties"]["val"]
+    val_default = schema["default"]["dataset"]["val"]
+    evaluate = schema["properties"]["evaluate"]
+    evaluate_default = schema["default"]["evaluate"]
+    inference = inference_schema["properties"]["inference"]
+    inference_default = inference_schema["default"]["inference"]
+
+    metadata_match_eval = val["properties"]["metadata_match_eval"]
+    assert metadata_match_eval["type"] == "bool"
+    assert metadata_match_eval["default"] is False
+    assert val_default["metadata_match_eval"] is False
+
+    metadata_match_mode = val["properties"]["metadata_match_mode"]
+    assert metadata_match_mode["default"] == "scalar_attributes"
+    assert metadata_match_mode["enum"] == [
+        "scalar_attributes",
+        "scalar_plus_accessories",
+    ]
+    assert val_default["metadata_match_mode"] == "scalar_attributes"
+
+    pas_ground_truth_mode = evaluate["properties"]["pas_ground_truth_mode"]
+    assert pas_ground_truth_mode["default"] == "paired_caption"
+    assert pas_ground_truth_mode["enum"] == [
+        "paired_caption",
+        "scalar_attributes",
+        "scalar_plus_accessories",
+    ]
+    assert evaluate_default["pas_ground_truth_mode"] == "paired_caption"
+    assert "pas_ground_truth_mode" not in inference["properties"]
+    assert "pas_ground_truth_mode" not in inference_default
+
+
+def test_clip_attribute_pairs_file_structured_config():
+    """CLIP dataset items preserve attribute_pairs_file through OmegaConf."""
+    config = OmegaConf.structured(CLIPValDataConfig())
+    config = OmegaConf.merge(
+        config,
+        {
+            "datasets": [
+                {
+                    "image_dir": "/data/images",
+                    "attribute_pairs_file": "/data/test_pairs.json",
+                }
+            ]
+        },
+    )
+
+    serialized = OmegaConf.to_container(config, resolve=True)
+
+    assert serialized["datasets"][0]["attribute_pairs_file"] == "/data/test_pairs.json"

--- a/nvidia_tao_core/tests/test_common_config.py
+++ b/nvidia_tao_core/tests/test_common_config.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for configuration shared by PyTorch TAO models."""
+
+from nvidia_tao_core.config.common.common_config import TrainConfig
+
+
+def test_checkpointer_defaults_are_safe_and_bounded_opt_in():
+    config = TrainConfig().checkpointer
+    fields = type(config).__dataclass_fields__
+
+    assert config.enable_topk is False
+    assert config.replace_periodic is False
+    assert config.monitor is None
+    assert config.mode is None
+    assert config.save_top_k == 1
+    assert config.filename == "model_best_{epoch:03d}"
+    assert config.dirpath is None
+    assert config.auto_insert_metric_name is False
+    assert fields["monitor"].metadata["default_value"] is None
+    assert fields["mode"].metadata["default_value"] is None
+    assert fields["dirpath"].metadata["default_value"] is None

--- a/nvidia_tao_core/tests/test_downstream_dinov3_backbones.py
+++ b/nvidia_tao_core/tests/test_downstream_dinov3_backbones.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drift guard for DINOv3 backbone options in downstream task configs (bug 6465432).
+
+DINOv3 backbones are registered as selectable backbones for the segformer and
+visual_changenet dense tasks (see nvidia_tao_pytorch/config/{segformer,
+visual_changenet}/default_config.py). tao-core mirrors those configs and is the
+source the tao-skills-external schemas are generated from, so it must carry the
+same backbone options or the generated skill schemas drift.
+"""
+from dataclasses import fields
+
+import pytest
+
+from nvidia_tao_core.config.segformer.default_config import (
+    BackboneConfig as SegformerBackboneConfig,
+)
+from nvidia_tao_core.config.visual_changenet.default_config import (
+    BackboneConfig as ChangeNetBackboneConfig,
+)
+
+# The DINOv3 backbones registered for dense downstream tasks in tao-pytorch.
+# 7B is intentionally excluded - not a registered downstream backbone.
+DINOV3_DOWNSTREAM_BACKBONES = [
+    "vit_small_dinov3",
+    "vit_small_plus_dinov3",
+    "vit_base_dinov3",
+    "vit_large_dinov3",
+    "vit_huge_plus_dinov3",
+]
+
+
+def _backbone_type_options(backbone_config_cls):
+    """Return the backbone ``type`` field's valid_options as a list of strings."""
+    (type_field,) = [f for f in fields(backbone_config_cls) if f.name == "type"]
+    return type_field.metadata["valid_options"].split(",")
+
+
+@pytest.mark.parametrize(
+    "backbone_config_cls",
+    [SegformerBackboneConfig, ChangeNetBackboneConfig],
+    ids=["segformer", "visual_changenet"],
+)
+def test_dinov3_backbones_present(backbone_config_cls):
+    options = _backbone_type_options(backbone_config_cls)
+    missing = [b for b in DINOV3_DOWNSTREAM_BACKBONES if b not in options]
+    assert not missing, f"config backbone enum missing DINOv3 options: {missing}"


### PR DESCRIPTION
Faithful sync of private GitLab `release/7.1.0` (source `aa9eb9d`). Telemetry module + internal metrics/auth stripped per sync policy; SECURITY.md present. Branch cut from the pre-enrichment base, so public-only files on main (CONTRIBUTORS.md, hooks, .github) are preserved on merge. Internal CI/pyarmor excluded.