### PR TITLE
[TAO-0000][Feature] Add Cosmos3 TAO configuration contracts

### DIFF
--- a/nvidia_tao_core/loggers/logging.py
+++ b/nvidia_tao_core/loggers/logging.py
@@ -12,7 +12,6 @@ import logging as _logging
 import os
 
 
-
 def _status_callback(data_string):
     """Forward status to the control plane when its optional stack is present.
 

--- a/nvidia_tao_core/loggers/logging.py
+++ b/nvidia_tao_core/loggers/logging.py
@@ -11,7 +11,23 @@ import json
 import logging as _logging
 import os
 
-from nvidia_tao_core.microservices.handlers.cloud_handlers.utils import status_callback
+
+
+def _status_callback(data_string):
+    """Forward status to the control plane when its optional stack is present.
+
+    File status logging is used inside model containers that intentionally do
+    not install the TAO API server's full cloud, database, and Kubernetes
+    dependency graph.  Importing that graph at module import time made even
+    ``StatusLogger`` unusable in those containers.
+    """
+
+    try:
+        from nvidia_tao_core.microservices.handlers.cloud_handlers.utils import status_callback
+    except ImportError as exc:
+        logger.debug("TAO control-plane status callback unavailable: %s", exc)
+        return
+    status_callback(data_string)
 
 
 class MessageFormatter(_logging.Formatter):
@@ -192,7 +208,7 @@ class BaseLogger(object):
             if self.is_master:
                 self.log(verbosity_level, data_string)
                 self.flush()
-                status_callback(data_string)
+                _status_callback(data_string)
 
 
 class StatusLogger(BaseLogger):

--- a/nvidia_tao_core/loggers/logging.py
+++ b/nvidia_tao_core/loggers/logging.py
@@ -20,7 +20,6 @@ def _status_callback(data_string):
     dependency graph.  Importing that graph at module import time made even
     ``StatusLogger`` unusable in those containers.
     """
-
     try:
         from nvidia_tao_core.microservices.handlers.cloud_handlers.utils import status_callback
     except ImportError as exc:

--- a/nvidia_tao_core/microservices/handlers/__init__.py
+++ b/nvidia_tao_core/microservices/handlers/__init__.py
@@ -1,20 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""API handlers module - provides direct access to specialized handler classes"""
+"""API handlers with backwards-compatible lazy class imports.
 
-# Import all handlers for direct access
-from .dataset_handler import DatasetHandler
-from .workspace_handler import WorkspaceHandler
-from .experiment_handler import ExperimentHandler
-from .job_handler import JobHandler
-from .spec_handler import SpecHandler
-from .mongo_handler import MongoBackupHandler
-from .model_handler import ModelHandler
+Importing one lightweight handler must not initialize every cloud, database,
+and orchestration handler.  This is important in model action containers,
+which use the inference server but not the TAO API service.
+"""
 
-# Import inference microservice servers
-from .base_inference_microservice_server import BaseInferenceMicroserviceServer
-from .huggingface_inference_microservice_server import HuggingFaceInferenceMicroserviceServer
+from importlib import import_module
 
 # Export all handlers
 __all__ = [
@@ -29,3 +23,30 @@ __all__ = [
     'BaseInferenceMicroserviceServer',
     'HuggingFaceInferenceMicroserviceServer',
 ]
+
+_HANDLERS = {
+    "DatasetHandler": ("dataset_handler", "DatasetHandler"),
+    "WorkspaceHandler": ("workspace_handler", "WorkspaceHandler"),
+    "ExperimentHandler": ("experiment_handler", "ExperimentHandler"),
+    "JobHandler": ("job_handler", "JobHandler"),
+    "SpecHandler": ("spec_handler", "SpecHandler"),
+    "MongoBackupHandler": ("mongo_handler", "MongoBackupHandler"),
+    "ModelHandler": ("model_handler", "ModelHandler"),
+    "BaseInferenceMicroserviceServer": (
+        "base_inference_microservice_server",
+        "BaseInferenceMicroserviceServer",
+    ),
+    "HuggingFaceInferenceMicroserviceServer": (
+        "huggingface_inference_microservice_server",
+        "HuggingFaceInferenceMicroserviceServer",
+    ),
+}
+
+
+def __getattr__(name):
+    if name not in _HANDLERS:
+        raise AttributeError(name)
+    module_name, attribute = _HANDLERS[name]
+    value = getattr(import_module(f"{__name__}.{module_name}"), attribute)
+    globals()[name] = value
+    return value

--- a/nvidia_tao_core/microservices/handlers/__init__.py
+++ b/nvidia_tao_core/microservices/handlers/__init__.py
@@ -7,6 +7,7 @@ Importing one lightweight handler must not initialize every cloud, database,
 and orchestration handler.  This is important in model action containers,
 which use the inference server but not the TAO API service.
 """
+# pylint: disable=undefined-all-variable
 
 from importlib import import_module
 

--- a/nvidia_tao_core/microservices/utils/__init__.py
+++ b/nvidia_tao_core/microservices/utils/__init__.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Microservices utilities module - consolidated utility functions"""
+"""Microservices utilities with lazy optional-module loading."""
+
+from importlib import import_module
 
 # Import key utilities for easy access
 from .core_utils import *  # noqa: F403
-from .handler_utils import *  # noqa: F403
-from .stateless_handler_utils import *  # noqa: F403
 
 __all__ = [  # noqa: F405
     # Core utilities (files)
@@ -32,3 +32,22 @@ __all__ = [  # noqa: F405
     'job_utils',
     'specs_utils'
 ]
+
+_LAZY_MODULES = set(__all__)
+_LEGACY_SYMBOL_MODULES = ("handler_utils", "stateless_handler_utils")
+
+
+def __getattr__(name):
+    if name in _LAZY_MODULES:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    # Preserve legacy direct symbol access without importing these large
+    # modules until the symbol is actually requested.
+    for module_name in _LEGACY_SYMBOL_MODULES:
+        module = import_module(f"{__name__}.{module_name}")
+        if hasattr(module, name):
+            value = getattr(module, name)
+            globals()[name] = value
+            return value
+    raise AttributeError(name)

--- a/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
+++ b/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import builtins
+import json
+import sys
+
+
+def test_handlers_package_does_not_eagerly_import_api_handlers() -> None:
+    import nvidia_tao_core.microservices.handlers  # noqa: F401
+
+    assert "nvidia_tao_core.microservices.handlers.dataset_handler" not in sys.modules
+    assert "nvidia_tao_core.microservices.handlers.job_handler" not in sys.modules
+
+
+def test_file_status_logger_survives_missing_control_plane_dependencies(tmp_path, monkeypatch) -> None:
+    from nvidia_tao_core.loggers.logging import Status, StatusLogger
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.startswith("nvidia_tao_core.microservices.handlers.cloud_handlers"):
+            raise ImportError("control plane intentionally absent")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    status_path = tmp_path / "status.json"
+    status = StatusLogger(filename=status_path, is_master=True)
+    status.kpi = {"validation_loss": 0.25}
+    status.write(status_level=Status.SUCCESS, message="done")
+
+    record = json.loads(status_path.read_text().strip())
+    assert record["status"] == "SUCCESS"
+    assert record["kpi"]["validation_loss"] == 0.25

--- a/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
+++ b/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
@@ -7,7 +7,7 @@ import sys
 
 
 def test_handlers_package_does_not_eagerly_import_api_handlers() -> None:
-    import nvidia_tao_core.microservices.handlers  # noqa: F401
+    import nvidia_tao_core.microservices.handlers  # noqa: F401  # pylint: disable=unused-import
 
     assert "nvidia_tao_core.microservices.handlers.dataset_handler" not in sys.modules
     assert "nvidia_tao_core.microservices.handlers.job_handler" not in sys.modules

--- a/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
+++ b/nvidia_tao_core/tests/test_lightweight_runtime_imports.py
@@ -2,15 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import builtins
+import importlib
 import json
 import sys
 
 
 def test_handlers_package_does_not_eagerly_import_api_handlers() -> None:
-    import nvidia_tao_core.microservices.handlers  # noqa: F401  # pylint: disable=unused-import
-
-    assert "nvidia_tao_core.microservices.handlers.dataset_handler" not in sys.modules
-    assert "nvidia_tao_core.microservices.handlers.job_handler" not in sys.modules
+    package_name = "nvidia_tao_core.microservices.handlers"
+    previous_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == package_name or name.startswith(f"{package_name}.")
+    }
+    for name in previous_modules:
+        sys.modules.pop(name, None)
+    try:
+        importlib.import_module(package_name)
+        assert f"{package_name}.dataset_handler" not in sys.modules
+        assert f"{package_name}.job_handler" not in sys.modules
+    finally:
+        for name in list(sys.modules):
+            if name == package_name or name.startswith(f"{package_name}."):
+                sys.modules.pop(name, None)
+        sys.modules.update(previous_modules)
 
 
 def test_file_status_logger_survives_missing_control_plane_dependencies(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Add the repository-owned Cosmos3 configuration and schema support required by the reproducible TAO workflows.

This is the GitHub-main replacement for work developed before the GitLab repositories were discontinued.

## Migration contract

- Base: `main`
- Source branch: `dev/ram/cosmos3-tao-reproducibility`
- Branch prefix: `dev/ram/`
- Repository history, not an image or generated runtime patch, is the source of truth.
- No credentials or user-specific runtime paths are included.