### PR TITLE
[TAO-0000][Bugfix] Fix Qwen3-VL patch embedding backward on cuDNN 9.20

### DIFF
--- a/nvidia_tao_core/microservices/handlers/huggingface_inference_microservice_server.py
+++ b/nvidia_tao_core/microservices/handlers/huggingface_inference_microservice_server.py
@@ -40,6 +40,22 @@ logging.getLogger('nvidia_tao_core').setLevel(tao_log_level)
 logger = logging.getLogger(__name__)
 
 
+def _linear_patch_embed_forward(self, hidden_states):
+    """Apply Qwen3-VL patch projection without invoking Conv3d."""
+    import torch.nn.functional as F
+
+    target_dtype = self.proj.weight.dtype
+    hidden_states = hidden_states.view(
+        -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size,
+    )
+    flattened_inputs = hidden_states.to(dtype=target_dtype).flatten(1)
+    flattened_weights = self.proj.weight.flatten(1)
+    return F.linear(flattened_inputs, flattened_weights, self.proj.bias)
+
+
+_linear_patch_embed_forward._tao_linear_patch_embed = True
+
+
 def _apply_qwen3vl_cudnn_workaround() -> None:
     # cuDNN 9.20 on sm_80 (A100) has no Conv3d engine for kernel spatial size
     # >= 16 in bf16/fp16 with the default NCDHW layout — Qwen3-VL's PatchEmbed
@@ -50,7 +66,6 @@ def _apply_qwen3vl_cudnn_workaround() -> None:
     # unlike the channels-last Conv3d workaround, supports both forward and
     # backward on the affected release runtime.
     try:
-        import torch.nn.functional as F
         from transformers.models.qwen3_vl.modeling_qwen3_vl import (
             Qwen3VLVisionPatchEmbed,
         )
@@ -60,17 +75,7 @@ def _apply_qwen3vl_cudnn_workaround() -> None:
     if getattr(Qwen3VLVisionPatchEmbed.forward, "_tao_linear_patch_embed", False):
         return
 
-    def forward(self, hidden_states):
-        target_dtype = self.proj.weight.dtype
-        hidden_states = hidden_states.view(
-            -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size,
-        )
-        flattened_inputs = hidden_states.to(dtype=target_dtype).flatten(1)
-        flattened_weights = self.proj.weight.flatten(1)
-        return F.linear(flattened_inputs, flattened_weights, self.proj.bias)
-
-    forward._tao_linear_patch_embed = True
-    Qwen3VLVisionPatchEmbed.forward = forward
+    Qwen3VLVisionPatchEmbed.forward = _linear_patch_embed_forward
     logger.info("Applied linear Qwen3-VL PatchEmbed workaround for the cuDNN 9.20 Conv3d gap")
 
 

--- a/nvidia_tao_core/microservices/handlers/huggingface_inference_microservice_server.py
+++ b/nvidia_tao_core/microservices/handlers/huggingface_inference_microservice_server.py
@@ -45,29 +45,33 @@ def _apply_qwen3vl_cudnn_workaround() -> None:
     # >= 16 in bf16/fp16 with the default NCDHW layout — Qwen3-VL's PatchEmbed
     # (patch_size=16, temporal_patch_size=2) hits this exactly and raises
     # "GET was unable to find an engine to execute this computation". cuDNN's
-    # NDHWC engines cover the same shape, so running the conv in
-    # channels_last_3d memory format avoids the gap without touching dtype.
+    # Avoid cuDNN for this non-overlapping patch projection. Flattening each
+    # patch and the Conv3d kernel gives the exact same affine operation and,
+    # unlike the channels-last Conv3d workaround, supports both forward and
+    # backward on the affected release runtime.
     try:
-        import torch
-        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionPatchEmbed
+        import torch.nn.functional as F
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLVisionPatchEmbed,
+        )
     except ImportError:
         return
 
-    if getattr(Qwen3VLVisionPatchEmbed.forward, "_tao_channels_last_3d", False):
+    if getattr(Qwen3VLVisionPatchEmbed.forward, "_tao_linear_patch_embed", False):
         return
 
     def forward(self, hidden_states):
         target_dtype = self.proj.weight.dtype
         hidden_states = hidden_states.view(
             -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size,
-        ).to(dtype=target_dtype, memory_format=torch.channels_last_3d)
-        if not self.proj.weight.is_contiguous(memory_format=torch.channels_last_3d):
-            self.proj.weight.data = self.proj.weight.data.to(memory_format=torch.channels_last_3d)
-        return self.proj(hidden_states).reshape(-1, self.embed_dim)
+        )
+        flattened_inputs = hidden_states.to(dtype=target_dtype).flatten(1)
+        flattened_weights = self.proj.weight.flatten(1)
+        return F.linear(flattened_inputs, flattened_weights, self.proj.bias)
 
-    forward._tao_channels_last_3d = True
+    forward._tao_linear_patch_embed = True
     Qwen3VLVisionPatchEmbed.forward = forward
-    logger.info("Applied channels_last_3d workaround for Qwen3-VL PatchEmbed (cuDNN 9.20 conv3d gap)")
+    logger.info("Applied linear Qwen3-VL PatchEmbed workaround for the cuDNN 9.20 Conv3d gap")
 
 
 _apply_qwen3vl_cudnn_workaround()

--- a/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
+++ b/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the Qwen3-VL patch-embedding runtime workaround."""
+
+from types import SimpleNamespace
+
+import torch
+from nvidia_tao_core.microservices.handlers import (
+    huggingface_inference_microservice_server as server,
+)
+from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionPatchEmbed
+
+
+def test_qwen3vl_patch_embed_workaround_supports_backward():
+    config = SimpleNamespace(
+        patch_size=4,
+        temporal_patch_size=2,
+        in_channels=3,
+        hidden_size=8,
+    )
+    module = Qwen3VLVisionPatchEmbed(config)
+    hidden_states = torch.randn(5 * 3 * 2 * 4 * 4, requires_grad=True)
+
+    output = module(hidden_states)
+    output.sum().backward()
+
+    assert getattr(module.forward, "_tao_linear_patch_embed", False)
+    assert output.shape == (5, 8)
+    assert hidden_states.grad is not None
+    assert module.proj.weight.grad is not None
+
+
+def test_qwen3vl_patch_embed_workaround_is_idempotent():
+    patched_forward = Qwen3VLVisionPatchEmbed.forward
+
+    server._apply_qwen3vl_cudnn_workaround()
+
+    assert Qwen3VLVisionPatchEmbed.forward is patched_forward

--- a/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
+++ b/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
@@ -45,3 +45,21 @@ def test_qwen3vl_patch_embed_workaround_is_idempotent():
     server._apply_qwen3vl_cudnn_workaround()
 
     assert qwen3vl_patch_embed.forward is patched_forward
+
+
+def test_linear_patch_embed_math_is_covered_without_transformers():
+    """The cuDNN replacement remains tested when Transformers is absent."""
+    module = SimpleNamespace(
+        in_channels=3,
+        temporal_patch_size=2,
+        patch_size=4,
+        proj=torch.nn.Linear(3 * 2 * 4 * 4, 8),
+    )
+    hidden_states = torch.randn(5 * 3 * 2 * 4 * 4, requires_grad=True)
+
+    output = server._linear_patch_embed_forward(module, hidden_states)
+    output.sum().backward()
+
+    assert output.shape == (5, 8)
+    assert hidden_states.grad is not None
+    assert module.proj.weight.grad is not None

--- a/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
+++ b/nvidia_tao_core/tests/microservices/handlers/test_qwen3vl_patch_embed.py
@@ -5,21 +5,28 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from nvidia_tao_core.microservices.handlers import (
     huggingface_inference_microservice_server as server,
 )
-from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionPatchEmbed
+
+
+def _qwen3vl_patch_embed_class():
+    """Load the optional Transformers implementation used by this regression."""
+    module = pytest.importorskip("transformers.models.qwen3_vl.modeling_qwen3_vl")
+    return module.Qwen3VLVisionPatchEmbed
 
 
 def test_qwen3vl_patch_embed_workaround_supports_backward():
+    qwen3vl_patch_embed = _qwen3vl_patch_embed_class()
     config = SimpleNamespace(
         patch_size=4,
         temporal_patch_size=2,
         in_channels=3,
         hidden_size=8,
     )
-    module = Qwen3VLVisionPatchEmbed(config)
+    module = qwen3vl_patch_embed(config)
     hidden_states = torch.randn(5 * 3 * 2 * 4 * 4, requires_grad=True)
 
     output = module(hidden_states)
@@ -32,8 +39,9 @@ def test_qwen3vl_patch_embed_workaround_supports_backward():
 
 
 def test_qwen3vl_patch_embed_workaround_is_idempotent():
-    patched_forward = Qwen3VLVisionPatchEmbed.forward
+    qwen3vl_patch_embed = _qwen3vl_patch_embed_class()
+    patched_forward = qwen3vl_patch_embed.forward
 
     server._apply_qwen3vl_cudnn_workaround()
 
-    assert Qwen3VLVisionPatchEmbed.forward is patched_forward
+    assert qwen3vl_patch_embed.forward is patched_forward


### PR DESCRIPTION
## Summary

- replace the Qwen3-VL patch-embedding Conv3D path with equivalent linear operations when the cuDNN 9.20 BF16 engine is unavailable
- preserve forward equivalence while restoring gradient flow during training
- cover the workaround with focused forward/backward tests

## Validation

- 2 focused TAO Core tests passed in the validated Cosmos image
- dense and PEFT Cosmos video training completed successfully with this patch