### PR TITLE
[TAO-2511][Feature] Add Visual ChangeNet DINOv3 7B configuration

### DIFF
--- a/nvidia_tao_core/config/visual_changenet/default_config.py
+++ b/nvidia_tao_core/config/visual_changenet/default_config.py
@@ -131,7 +131,8 @@ class BackboneConfig:
         valid_options=(
             "fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,"
             "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,"
-            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3"
+            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,"
+            "vit_huge_plus_dinov3,vit_7b_dinov3"
         )
     )
     feat_downsample: bool = BOOL_FIELD(

--- a/nvidia_tao_core/tests/test_downstream_dinov3_backbones.py
+++ b/nvidia_tao_core/tests/test_downstream_dinov3_backbones.py
@@ -20,9 +20,8 @@ from nvidia_tao_core.config.visual_changenet.default_config import (
     BackboneConfig as ChangeNetBackboneConfig,
 )
 
-# The DINOv3 backbones registered for dense downstream tasks in tao-pytorch.
-# 7B is intentionally excluded - not a registered downstream backbone.
-DINOV3_DOWNSTREAM_BACKBONES = [
+# DINOv3 backbones shared by SegFormer and Visual ChangeNet in tao-pytorch.
+DINOV3_SHARED_BACKBONES = [
     "vit_small_dinov3",
     "vit_small_plus_dinov3",
     "vit_base_dinov3",
@@ -44,5 +43,11 @@ def _backbone_type_options(backbone_config_cls):
 )
 def test_dinov3_backbones_present(backbone_config_cls):
     options = _backbone_type_options(backbone_config_cls)
-    missing = [b for b in DINOV3_DOWNSTREAM_BACKBONES if b not in options]
+    missing = [b for b in DINOV3_SHARED_BACKBONES if b not in options]
     assert not missing, f"config backbone enum missing DINOv3 options: {missing}"
+
+
+def test_visual_changenet_has_7b_dinov3():
+    """Visual ChangeNet additionally supports the DINOv3 7B variant."""
+    options = _backbone_type_options(ChangeNetBackboneConfig)
+    assert "vit_7b_dinov3" in options


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add `vit_7b_dinov3` to the tao-core Visual ChangeNet backbone enum and extend the downstream drift test with a Visual ChangeNet-specific 7B assertion. SegFormer remains limited to its existing five DINOv3 variants.

### Why are the changes needed?

tao-core is the configuration source mirrored by downstream schemas. It must expose the same Visual ChangeNet DINOv3 variants as tao-pytorch so generated interfaces do not drift.

### Related issues

JIRA: TAO-2511.

Companion implementation: tao-pytorch branch `TAO-2511-frozen-dinov3-aoi`.
Companion workflow/schema update: tao-skill-bank branch `TAO-2511-frozen-dinov3-aoi`.

### Does this PR introduce _any_ user-facing change?

Yes. Generated Visual ChangeNet configurations can select `vit_7b_dinov3`. Existing defaults and SegFormer options are unchanged.

### How was this patch tested?

- Required TAO image, downstream DINOv3 config drift suite: **3 passed**.
- Exact PR-range CI hooks: license, pylint, pydocstyle, and flake8 passed.
- `git diff --check` and no-Markdown checks passed.
- Independent panel review completed with no remaining blockers.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

### Release note

```release-note
Visual ChangeNet configuration now exposes the DINOv3 ViT-7B backbone option.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`)
- [x] I have read the contributing guidelines
- [x] The code follows the project style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All applicable tests pass locally
- [x] Inline configuration metadata is updated
- [ ] A version or changelog update is not required for this patch
- [x] No secrets, credentials, proprietary data, or customer data are included
- [x] I understand the contribution is licensed under the repository license

### Notes for reviewers

No Markdown files are changed. The split regression expectation is intentional: five variants are shared with SegFormer, while 7B is Visual ChangeNet-only.