### PR TITLE
[TAOVN-1251][Feature] Add NVPanoptix3Dv2 configs

### DIFF
--- a/nvidia_tao_core/config/nvpanoptix3d_v2/__init__.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 config."""

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/dataset.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/dataset.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the dataset."""
+
+from typing import List, Optional
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    LIST_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class PhotometricAugmentationConfig:
+    """Geometry-safe photometric augmentation config.
+
+    One recipe is sampled per multi-view sample and applied identically to
+    every view, so no spatial operation or geometric target is modified.
+    Training only.
+    """
+
+    enabled: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable photometric augmentation",
+        description="Flag to enable RGB-only training augmentation.",
+    )
+    color_jitter_prob: float = FLOAT_FIELD(
+        value=0.8,
+        default_value=0.8,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="color jitter probability",
+        description="Probability of applying brightness/contrast/saturation jitter.",
+    )
+    brightness: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        display_name="brightness",
+        description="Maximum relative brightness jitter.",
+    )
+    contrast: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        display_name="contrast",
+        description="Maximum relative contrast jitter.",
+    )
+    saturation: float = FLOAT_FIELD(
+        value=0.15,
+        default_value=0.15,
+        valid_min=0.0,
+        display_name="saturation",
+        description="Maximum relative saturation jitter.",
+    )
+    gamma_exposure_prob: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="gamma/exposure probability",
+        description="Probability of applying the gamma and exposure jitter.",
+    )
+    gamma: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="gamma",
+        description="Maximum gamma jitter. Must be in [0, 1).",
+    )
+    exposure_ev: float = FLOAT_FIELD(
+        value=0.15,
+        default_value=0.15,
+        valid_min=0.0,
+        display_name="exposure EV",
+        description="Maximum exposure jitter in EV stops.",
+    )
+    grayscale_prob: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="grayscale probability",
+        description="Probability of converting a sample to grayscale.",
+    )
+
+
+@dataclass
+class PanopticDatasetConfig:
+    """Dataset config for the panoptic variant (preprocessed ScanNet++ trees)."""
+
+    train_preprocessed_root: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="training preprocessed root",
+        description="""
+        Preprocessed ScanNet++ training root containing
+        :code:`all_metadata.npz`, :code:`categories.json`, and the scene
+        directories. The metadata file includes the training pair table.""",
+    )
+    val_preprocessed_root: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="validation preprocessed root",
+        description="""
+        Preprocessed ScanNet++ validation root containing
+        :code:`all_metadata.npz`, :code:`categories.json`, and the scene
+        directories. The metadata file includes the validation pair table.""",
+    )
+    photometric_augmentation: PhotometricAugmentationConfig = DATACLASS_FIELD(
+        PhotometricAugmentationConfig(),
+        display_name="photometric augmentation",
+        description="Configuration parameters for the training-only RGB augmentation.",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=2,
+        display_name="number of views",
+        description="Number of views per multi-view sample.",
+        popular="yes",
+    )
+    randomize_view_order: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="randomize view order",
+        description="""
+        Training only. Select either central anchor as VGGT reference view 0,
+        then shuffle the remaining views. Validation and test ignore this flag
+        and use stable index-seeded sampling.""",
+    )
+    num_workers: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=0,
+        display_name="num workers",
+        description="Number of dataloader workers for every split.",
+    )
+    pairs_per_scene: int = INT_FIELD(
+        value=50,
+        default_value=50,
+        valid_min=1,
+        display_name="pairs per scene",
+        description="Samples drawn per scene from the primary root.",
+    )
+    batch_size: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="batch size",
+        description="Number of multi-view samples per GPU.",
+        popular="yes",
+    )
+    resolution: List[List[int]] = LIST_FIELD(
+        arrList=[[518, 518], [518, 378], [518, 322]],
+        default_value=[[518, 518], [518, 378], [518, 322]],
+        display_name="resolution buckets",
+        description="""
+        Aspect-ratio buckets as [H, W] pairs. One bucket is selected per sample
+        from the anchor view's aspect ratio; a single entry reproduces
+        fixed-resolution behaviour.""",
+    )
+
+
+@dataclass
+class ReasoningDatasetConfig:
+    """Dataset config for the reasoning variant (JSONL reasoning manifests)."""
+
+    train_manifest: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="train manifest",
+        description="""
+        Path to the training JSONL manifest. Each line holds the view image
+        paths, the RGB-encoded panoptic PNGs, the instruction/answer pair, and
+        the target instance id.""",
+    )
+    val_manifest: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="val manifest",
+        description="Path to the validation JSONL manifest. Null disables validation.",
+    )
+    require_seg_token: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="require SEG token",
+        description="""
+        Drop training records whose answer has a target instance but no
+        :code:`[SEG]` token, which would otherwise yield no mask supervision.""",
+    )
+    resolution: List[int] = LIST_FIELD(
+        arrList=[518, 518],
+        default_value=[518, 518],
+        display_name="resolution",
+        description="Square letterbox size [H, W] every view is resized to, matching VGGT.",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=1,
+        display_name="number of views",
+        description="Number of views per sample. 1 reproduces the single-view setting.",
+        popular="yes",
+    )
+    batch_size: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="batch size",
+        description="Number of multi-view samples per GPU.",
+        popular="yes",
+    )
+    num_workers: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=0,
+        display_name="num workers",
+        description="Number of dataloader workers for every split.",
+    )
+    depth_scale: float = FLOAT_FIELD(
+        value=1000.0,
+        default_value=1000.0,
+        math_cond="> 0.0",
+        display_name="depth scale",
+        description="""
+        Stored depth units per metre (ScanNet++: 1000). Per-record values in
+        the manifest override this fallback.""",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2DatasetConfig:
+    """Data config.
+
+    Each variant owns a self-contained sub-block; :code:`model.model_type`
+    selects which one the data module reads.
+    """
+
+    panoptic: PanopticDatasetConfig = DATACLASS_FIELD(
+        PanopticDatasetConfig(),
+        display_name="panoptic dataset",
+        description="Dataset for the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningDatasetConfig = DATACLASS_FIELD(
+        ReasoningDatasetConfig(),
+        display_name="reasoning dataset",
+        description="Dataset for the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/default_config.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/default_config.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Default config file."""
+
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.utils.types import (
+    DATACLASS_FIELD,
+)
+from nvidia_tao_core.config.common.common_config import (
+    CommonExperimentConfig
+)
+
+from nvidia_tao_core.config.nvpanoptix3d_v2.dataset import NVPanoptix3Dv2DatasetConfig
+from nvidia_tao_core.config.nvpanoptix3d_v2.model import NVPanoptix3Dv2ModelConfig
+from nvidia_tao_core.config.nvpanoptix3d_v2.train import NVPanoptix3Dv2TrainExpConfig
+from nvidia_tao_core.config.nvpanoptix3d_v2.inference import NVPanoptix3Dv2InferenceExpConfig
+from nvidia_tao_core.config.nvpanoptix3d_v2.evaluate import NVPanoptix3Dv2EvaluateExpConfig
+from nvidia_tao_core.config.nvpanoptix3d_v2.export import NVPanoptix3Dv2ExportExpConfig
+
+
+@dataclass
+class ExperimentConfig(CommonExperimentConfig):
+    """Experiment config."""
+
+    model: NVPanoptix3Dv2ModelConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2ModelConfig(),
+        description="Configurable parameters to construct the model for the NVPanoptix3Dv2 experiment.",
+    )
+    dataset: NVPanoptix3Dv2DatasetConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2DatasetConfig(),
+        description="Configurable parameters to construct the dataset for the NVPanoptix3Dv2 experiment.",
+    )
+    train: NVPanoptix3Dv2TrainExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2TrainExpConfig(),
+        description="Configurable parameters to construct the trainer for the NVPanoptix3Dv2 experiment.",
+    )
+    inference: NVPanoptix3Dv2InferenceExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2InferenceExpConfig(),
+        description="Configurable parameters to construct the inferencer for the NVPanoptix3Dv2 experiment.",
+    )
+    evaluate: NVPanoptix3Dv2EvaluateExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2EvaluateExpConfig(),
+        description="Configurable parameters to construct the evaluator for the NVPanoptix3Dv2 experiment.",
+    )
+    export: NVPanoptix3Dv2ExportExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2ExportExpConfig(),
+        description="Configurable parameters to construct the exporter for the NVPanoptix3Dv2 experiment.",
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/evaluate.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/evaluate.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the evaluation."""
+
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.common.common_config import EvaluateConfig
+from nvidia_tao_core.config.utils.types import FLOAT_FIELD
+
+
+@dataclass
+class NVPanoptix3Dv2EvaluateExpConfig(EvaluateConfig):
+    """NVPanoptix3Dv2 evaluation configuration."""
+
+    cls_threshold: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="class threshold",
+        description="Minimum class score for a query to enter panoptic post-processing.",
+    )
+    mask_threshold: float = FLOAT_FIELD(
+        value=0.25,
+        default_value=0.25,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="mask threshold",
+        description="Probability threshold binarizing the predicted masks.",
+    )
+    overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="overlap threshold",
+        description="""
+        Minimum fraction of a segment that must survive occlusion by
+        higher-scoring segments for it to be kept.""",
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/export.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/export.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for export."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.common.common_config import ExportConfig
+from nvidia_tao_core.config.utils.types import (
+    INT_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class NVPanoptix3Dv2ExportExpConfig(ExportConfig):
+    """NVPanoptix3Dv2 export ONNX experiment config."""
+
+    categories_json: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="categories json",
+        description="""
+        Path to a categories JSON (a list of :code:`{id, name, isthing}`
+        dicts) defining the vocabulary baked into the ONNX graph. Null uses
+        the dataset taxonomy.""",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=2,
+        description="Number of views in the exported multi-view input tensor.",
+        display_name="number of views",
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/inference.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/inference.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the inferencer."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.common.common_config import InferenceConfig
+from nvidia_tao_core.config.utils.types import (
+    BOOL_FIELD,
+    FLOAT_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class NVPanoptix3Dv2InferenceExpConfig(InferenceConfig):
+    """NVPanoptix3Dv2 inference configuration."""
+
+    cls_threshold: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="class threshold",
+        description="Minimum class score for a query to enter panoptic post-processing.",
+    )
+    mask_threshold: float = FLOAT_FIELD(
+        value=0.25,
+        default_value=0.25,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="mask threshold",
+        description="Probability threshold binarizing the predicted masks.",
+    )
+    overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="overlap threshold",
+        description="""
+        Minimum fraction of a segment that must survive occlusion by
+        higher-scoring segments for it to be kept.""",
+    )
+    categories_json: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="categories json",
+        description="""
+        Path to a categories JSON (a list of :code:`{id, name, isthing}` dicts)
+        defining the open-vocabulary class list to predict against. Null uses
+        the dataset's own categories.""",
+    )
+    output_dir: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="output directory",
+        description="Directory for prediction artifacts. Null uses results_dir.",
+    )
+    save_full_point_cloud: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="save full point cloud",
+        description="""
+        Reasoning variant only. Save one sample-level NPZ containing the full
+        RGB point cloud and fused predicted segmentation mask. This is opt-in
+        because dense multi-view point clouds can consume substantial disk
+        space.
+        """,
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/model.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/model.py
@@ -1,0 +1,536 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the model."""
+
+from typing import List, Optional
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    LIST_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class MetricDepthHeadConfig:
+    """Metric scale head config."""
+
+    enable: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable metric depth head",
+        description="""
+        Flag to enable the metric-scale head. When enabled a single scene-level
+        log-scale is regressed from the pooled VGGT patch tokens and applied to
+        the relative depth and world points of every view.""",
+    )
+    feat_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="scene token dim",
+        description="Channel width of the pooled VGGT patch token fed to the metric-scale head.",
+    )
+    hidden_dims: List[int] = LIST_FIELD(
+        arrList=[256, 64],
+        default_value=[256, 64],
+        display_name="hidden dims",
+        description="Hidden widths of the metric-scale MLP.",
+    )
+    metric_context_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=1,
+        display_name="metric context views",
+        description="""
+        Number of leading views used to estimate the single scene scale. The
+        estimated scale is then applied to every inference view, including
+        views outside this context window.""",
+    )
+    predict_shift: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="predict depth shift",
+        description="""
+        Also regress an additive depth shift, so
+        :code:`d_metric = s * d_rel + b`. This config is used by the reasoning
+        variant; the panoptic builder always uses scale-only correction. The
+        shift lives in depth units and is never applied to 3D points.""",
+    )
+
+
+@dataclass
+class BackboneConfig:
+    """Backbone config."""
+
+    pretrained_backbone_path: str = STR_FIELD(
+        value="",
+        default_value="",
+        display_name="pretrained backbone path",
+        description="""
+        Path to the pretrained VGGT checkpoint. When empty the backbone falls
+        back to the :code:`facebook/VGGT-1B` weights from the model hub.""",
+    )
+    load_from_hf: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="load backbone from HF",
+        description="""
+        Fall back to the :code:`facebook/VGGT-1B` hub weights when
+        pretrained_backbone_path is unset. Keep this off so a missing or
+        unmounted commercial checkpoint fails loudly instead of silently
+        pulling non-commercial weights.""",
+    )
+    strict_load: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="strict backbone load",
+        description="Require the VGGT checkpoint to match the built heads exactly.",
+    )
+    metric_depth_head: MetricDepthHeadConfig = DATACLASS_FIELD(
+        MetricDepthHeadConfig(),
+        display_name="metric depth head",
+        description="Configuration hyper parameters for the metric-scale head.",
+    )
+
+
+@dataclass
+class FeatureFusionConfig:
+    """Feature fusion config."""
+
+    dino_dim: int = INT_FIELD(
+        value=1024,
+        default_value=1024,
+        valid_min=1,
+        display_name="dino dim",
+        description="Channel width of the DINOv2 token stream.",
+    )
+    vggt_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="vggt dim",
+        description="Channel width of the VGGT token stream.",
+    )
+    hidden_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="hidden dim",
+        description="Channel width of the fused token map.",
+        popular="yes",
+    )
+    num_heads: int = INT_FIELD(
+        value=12,
+        default_value=12,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the per-view spatial mixer.",
+    )
+    num_layers: int = INT_FIELD(
+        value=3,
+        default_value=3,
+        valid_min=0,
+        display_name="number of layers",
+        description="Number of blocks in the per-view spatial mixer.",
+    )
+    ff_dim_mult: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=1,
+        display_name="feedforward dim multiplier",
+        description="Feedforward expansion ratio inside each spatial-mixer block.",
+    )
+
+
+@dataclass
+class PanopticDecoderConfig:
+    """Panoptic decoder config."""
+
+    hidden_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="hidden dim",
+        description="Channel width of the decoder queries and memory.",
+        popular="yes",
+    )
+    mask_dim: int = INT_FIELD(
+        value=384,
+        default_value=384,
+        valid_min=1,
+        display_name="mask dim",
+        description="Channel width of the high-resolution mask features.",
+    )
+    ff_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="feedforward dim",
+        description="Width of the feedforward network in the mask transformer.",
+    )
+    num_queries: int = INT_FIELD(
+        value=200,
+        default_value=200,
+        valid_min=1,
+        display_name="number of queries",
+        description="Number of learned object queries.",
+        popular="yes",
+    )
+    num_heads: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the mask transformer.",
+    )
+    dec_layers: int = INT_FIELD(
+        value=6,
+        default_value=6,
+        valid_min=1,
+        display_name="decoder layers",
+        description="Number of mask-transformer decoder layers.",
+    )
+    fixed_vocab: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="fixed vocabulary",
+        description="""
+        Flag to encode the full class vocabulary once up front. The collator
+        then performs cache lookups instead of re-encoding text every step.""",
+    )
+    label_mode: str = STR_FIELD(
+        value="sigmoid",
+        default_value="sigmoid",
+        display_name="label mode",
+        description="Classification head activation used for open-vocabulary labels.",
+        valid_options=",".join(["sigmoid", "softmax"])
+    )
+    deep_supervision: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="deep supervision",
+        description="Flag to supervise the intermediate decoder layer outputs.",
+    )
+    enable_objectness: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable objectness",
+        description="""
+        Flag to enable the vocabulary-independent matched/unmatched query
+        confidence head.""",
+    )
+
+
+@dataclass
+class UpscalerConfig:
+    """LoftUp mask-feature upscaler config."""
+
+    input_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="input dim",
+        description="Channel width of the fused token map fed to the upscaler.",
+    )
+    dim: int = INT_FIELD(
+        value=384,
+        default_value=384,
+        valid_min=1,
+        display_name="output dim",
+        description="Channel width of the upscaled mask features.",
+    )
+    output_stride: int = INT_FIELD(
+        value=2,
+        default_value=2,
+        valid_min=1,
+        display_name="output stride",
+        description="Stride of the upscaled mask features relative to the input image.",
+    )
+    patch_size: int = INT_FIELD(
+        value=14,
+        default_value=14,
+        valid_min=1,
+        display_name="patch size",
+        description="Patch size of the token map consumed by the upscaler.",
+    )
+    color_feats: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="use color features",
+        description="Flag to condition the upscaler on the input RGB image.",
+    )
+    n_freqs: int = INT_FIELD(
+        value=20,
+        default_value=20,
+        valid_min=1,
+        display_name="number of frequencies",
+        description="Number of Fourier frequencies in the implicit featurizer.",
+    )
+    num_heads: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the upscaler cross-attention blocks.",
+    )
+    num_layers: int = INT_FIELD(
+        value=2,
+        default_value=2,
+        valid_min=1,
+        display_name="number of layers",
+        description="Number of upscaler cross-attention blocks.",
+    )
+
+
+@dataclass
+class PanopticVariantConfig:
+    """Architecture of the panoptic-segmentation variant."""
+
+    feature_fusion: FeatureFusionConfig = DATACLASS_FIELD(
+        FeatureFusionConfig(),
+        display_name="feature fusion",
+        description="Configuration hyper parameters for the DINOv2/VGGT feature fusion.",
+    )
+    panoptic_decoder: PanopticDecoderConfig = DATACLASS_FIELD(
+        PanopticDecoderConfig(),
+        display_name="panoptic decoder",
+        description="Configuration hyper parameters for the panoptic segmentation decoder.",
+    )
+    upscaler: UpscalerConfig = DATACLASS_FIELD(
+        UpscalerConfig(),
+        display_name="upscaler",
+        description="Configuration hyper parameters for the mask-feature upscaler.",
+    )
+
+
+@dataclass
+class LoraConfig:
+    """LoRA adapter config for the Qwen reasoner."""
+
+    r: int = INT_FIELD(
+        value=16,
+        default_value=16,
+        valid_min=1,
+        display_name="LoRA rank",
+        description="Rank of the LoRA update matrices.",
+    )
+    alpha: int = INT_FIELD(
+        value=32,
+        default_value=32,
+        valid_min=1,
+        display_name="LoRA alpha",
+        description="LoRA scaling factor.",
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="LoRA dropout",
+        description="Dropout applied inside the LoRA adapters.",
+    )
+
+
+@dataclass
+class QwenConfig:
+    """Qwen vision-language reasoner config."""
+
+    model_id: str = STR_FIELD(
+        value="Qwen/Qwen3-VL-4B-Instruct",
+        default_value="Qwen/Qwen3-VL-4B-Instruct",
+        display_name="Qwen model id",
+        description="Hugging Face model id or local directory for Qwen3-VL-4B.",
+    )
+    seg_token: str = STR_FIELD(
+        value="[SEG]",
+        default_value="[SEG]",
+        display_name="segmentation token",
+        description="Added token whose hidden state is projected into the SAM3 prompt space.",
+    )
+    freeze_vision: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="freeze vision tower",
+        description="Flag to freeze the Qwen vision tower.",
+    )
+    dtype: str = STR_FIELD(
+        value="bfloat16",
+        default_value="bfloat16",
+        display_name="dtype",
+        description="Compute dtype for the Qwen weights.",
+        valid_options=",".join(["float32", "bfloat16", "float16"])
+    )
+    attn_implementation: str = STR_FIELD(
+        value="sdpa",
+        default_value="sdpa",
+        display_name="attention implementation",
+        description="Attention kernel used by the Qwen backbone.",
+        valid_options=",".join(["sdpa", "eager", "flash_attention_2"])
+    )
+    use_lora: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="use LoRA",
+        description="Train LoRA adapters instead of the full Qwen weights.",
+    )
+    lora: LoraConfig = DATACLASS_FIELD(
+        LoraConfig(),
+        display_name="LoRA",
+        description="Hyper parameters for the LoRA adapters.",
+    )
+
+
+@dataclass
+class Sam3Config:
+    """Frozen SAM3 mask-decoder config."""
+
+    checkpoint: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="SAM3 checkpoint",
+        description="""
+        Path to a local SAM3 checkpoint. Null downloads the weights from the
+        hub when load_from_hf is set.""",
+    )
+    load_from_hf: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="load SAM3 from HF",
+        description="Download the SAM3 weights from the hub when no checkpoint is given.",
+    )
+    resolution: int = INT_FIELD(
+        value=1008,
+        default_value=1008,
+        valid_min=32,
+        display_name="SAM3 resolution",
+        description="Square resolution the input views are resized to for SAM3.",
+    )
+
+
+@dataclass
+class SamBridgeConfig:
+    """``[SEG]``-to-SAM3 prompt projector config."""
+
+    sam_prompt_dim: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        valid_min=1,
+        display_name="SAM prompt dim",
+        description="Width of the SAM3 language-prompt tensor.",
+    )
+    hidden_dim: int = INT_FIELD(
+        value=4096,
+        default_value=4096,
+        valid_min=1,
+        display_name="projector hidden dim",
+        description="Hidden width of the ``[SEG]`` -> SAM prompt MLP.",
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.0,
+        default_value=0.0,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="projector dropout",
+        description="Dropout inside the projector MLP.",
+    )
+
+
+@dataclass
+class ReasoningVariantConfig:
+    """Architecture of the reasoning-segmentation variant."""
+
+    qwen: QwenConfig = DATACLASS_FIELD(
+        QwenConfig(),
+        display_name="Qwen reasoner",
+        description="Configuration hyper parameters for the Qwen VLM reasoner.",
+    )
+    sam3: Sam3Config = DATACLASS_FIELD(
+        Sam3Config(),
+        display_name="SAM3",
+        description="Configuration hyper parameters for the frozen SAM3 mask decoder.",
+    )
+    sam_bridge: SamBridgeConfig = DATACLASS_FIELD(
+        SamBridgeConfig(),
+        display_name="SAM bridge",
+        description="Configuration hyper parameters for the ``[SEG]`` prompt projector.",
+    )
+    point_mask_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="point mask threshold",
+        description="Foreground threshold applied to the SAM3 mask before lifting to 3D.",
+    )
+    point_conf_threshold: Optional[float] = FLOAT_FIELD(
+        value=None,
+        display_name="point confidence threshold",
+        description="""
+        Optional VGGT confidence gate on the lifted points. Null keeps every
+        geometrically valid point.""",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2ModelConfig:
+    """NVPanoptix3Dv2 model config.
+
+    Both variants share the frozen VGGT backbone and the metric scale head
+    under :code:`backbone`; :code:`model_type` selects which variant-specific
+    block is read and which Lightning module is built.
+    """
+
+    model_type: str = STR_FIELD(
+        value="panoptic",
+        default_value="panoptic",
+        display_name="model type",
+        description="""
+        Which NVPanoptix3Dv2 variant to build:
+        * :code:`panoptic`  -- open-vocabulary panoptic segmentation.
+        * :code:`reasoning` -- Qwen-driven reasoning segmentation.""",
+        valid_options=",".join(["panoptic", "reasoning"]),
+        popular="yes",
+    )
+    img_size: int = INT_FIELD(
+        value=518,
+        default_value=518,
+        valid_min=32,
+        display_name="image size",
+        description="Image size the VGGT backbone is instantiated for.",
+    )
+    patch_size: int = INT_FIELD(
+        value=14,
+        default_value=14,
+        valid_min=1,
+        display_name="patch size",
+        description="Patch size of the VGGT backbone.",
+    )
+    embed_dim: int = INT_FIELD(
+        value=1024,
+        default_value=1024,
+        valid_min=1,
+        display_name="embedding dim",
+        description="Token width of the VGGT backbone.",
+    )
+    backbone: BackboneConfig = DATACLASS_FIELD(
+        BackboneConfig(),
+        display_name="backbone",
+        description="""
+        Configuration hyper parameters for the frozen VGGT backbone and the
+        metric scale head. Shared by both variants.""",
+    )
+    panoptic: PanopticVariantConfig = DATACLASS_FIELD(
+        PanopticVariantConfig(),
+        display_name="panoptic variant",
+        description="Architecture of the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningVariantConfig = DATACLASS_FIELD(
+        ReasoningVariantConfig(),
+        display_name="reasoning variant",
+        description="Architecture of the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_core/config/nvpanoptix3d_v2/train.py
+++ b/nvidia_tao_core/config/nvpanoptix3d_v2/train.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the trainer."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_core.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    STR_FIELD
+)
+from nvidia_tao_core.config.common.common_config import TrainConfig
+
+
+@dataclass
+class MetricDepthLossConfig:
+    """Metric depth loss config."""
+
+    weight: float = FLOAT_FIELD(
+        value=5.0,
+        default_value=5.0,
+        valid_min=0.0,
+        display_name="metric depth weight",
+        description="Outer multiplier on the metric-depth loss. Set to 0 to disable.",
+    )
+    silog_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="SILog weight",
+        description="Weight of the scale-invariant log term.",
+    )
+    absrel_weight: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        display_name="AbsRel weight",
+        description="Weight of the auxiliary absolute-relative term. Set to 0 to disable.",
+    )
+    silog_lambda: float = FLOAT_FIELD(
+        value=0.85,
+        default_value=0.85,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="SILog lambda",
+        description="SILog variance-mixing constant.",
+    )
+    min_depth: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        math_cond="> 0.0",
+        display_name="min depth",
+        description="Lower bound of the supervised metric-depth range, in metres.",
+    )
+    max_depth: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        math_cond="> 0.0",
+        display_name="max depth",
+        description="Upper bound of the supervised metric-depth range, in metres.",
+    )
+
+
+@dataclass
+class PanopticLossConfig:
+    """Loss weights for the panoptic variant."""
+
+    class_weight: float = FLOAT_FIELD(
+        value=2.0,
+        default_value=2.0,
+        valid_min=0.0,
+        display_name="class loss coefficient",
+        description="Weight of the open-vocabulary classification loss.",
+        popular="yes",
+    )
+    rank_weight: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        display_name="rank loss coefficient",
+        description="""
+        Weight of the matched-query cross-entropy that trains the
+        one-label-per-query top-1 decision.""",
+    )
+    objectness_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="objectness loss coefficient",
+        description="Weight of the binary matched/unmatched query confidence loss.",
+    )
+    objectness_no_object_weight: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        display_name="objectness no-object coefficient",
+        description="Relative weight applied to the no-object objectness target.",
+    )
+    objectness_ignore_overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="objectness ignore overlap threshold",
+        description="""
+        Unmatched queries whose predicted mask lies at least this fraction on
+        ignored or crowd pixels receive no objectness target.""",
+    )
+    mask_weight: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        valid_min=0.0,
+        display_name="mask loss coefficient",
+        description="Weight of the point-sampled binary mask loss.",
+        popular="yes",
+    )
+    dice_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="dice loss coefficient",
+        description="Weight of the dice loss of the binary mask.",
+        popular="yes",
+    )
+    num_loss_points: int = INT_FIELD(
+        value=12288,
+        default_value=12288,
+        valid_min=1,
+        display_name="number of loss points",
+        description="Number of points sampled per mask for the mask and dice losses.",
+    )
+
+
+@dataclass
+class ReasoningLossConfig:
+    """Loss weights for the reasoning variant."""
+
+    text_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="text loss coefficient",
+        description="Weight of the Qwen next-token cross-entropy on the answer.",
+        popular="yes",
+    )
+    mask_weight: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        valid_min=0.0,
+        display_name="mask loss coefficient",
+        description="Weight of the SAM3 binary mask loss.",
+        popular="yes",
+    )
+    dice_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="dice loss coefficient",
+        description="Weight of the dice loss on the SAM3 mask.",
+        popular="yes",
+    )
+    score_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="score loss coefficient",
+        description="Weight of the SAM3 query-selection score loss.",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2TrainExpConfig(TrainConfig):
+    """Train experiment config."""
+
+    accum_iter: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="gradient accumulation iterations",
+        description="Number of batches accumulated before an optimizer step.",
+    )
+    lr: float = FLOAT_FIELD(
+        value=1.0e-4,
+        default_value=1.0e-4,
+        math_cond="> 0.0",
+        display_name="learning rate",
+        description="Peak learning rate after warmup.",
+    )
+    min_lr: float = FLOAT_FIELD(
+        value=1.0e-6,
+        default_value=1.0e-6,
+        valid_min=0.0,
+        display_name="minimum learning rate",
+        description="Floor of the cosine decay schedule.",
+    )
+    weight_decay: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        display_name="weight decay",
+        description="""
+        AdamW weight decay. Applied only to matrix and convolution weights;
+        norms, biases, scalar temperatures and embeddings get zero decay.""",
+    )
+    warmup_epochs: float = FLOAT_FIELD(
+        value=2.0,
+        default_value=2.0,
+        valid_min=0.0,
+        display_name="warmup epochs",
+        description="Length of the linear learning-rate warmup, in epochs.",
+    )
+    precision: str = STR_FIELD(
+        value="fp32",
+        default_value="fp32",
+        display_name="precision",
+        description="Precision to run the training on.",
+        valid_options=",".join(["fp32", "bf16", "fp16"])
+    )
+    is_dry_run: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="is dry run",
+        description="Flag to run the trainer in dry-run mode.",
+    )
+    clip_grad_norm: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="clip gradient norm",
+        description="Amount to clip the gradient by L2 norm. 0 disables clipping.",
+    )
+    val_check_interval: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="val check interval",
+        description="Fraction of a training epoch between validation runs.",
+    )
+    pretrained_model_path: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="pretrained model path",
+        description="""
+        Checkpoint to warm-start the model weights from. Ignored when a resume
+        checkpoint is present, which always takes priority.""",
+    )
+    log_interval: int = INT_FIELD(
+        value=50,
+        default_value=50,
+        valid_min=1,
+        display_name="log interval",
+        description="Number of training steps between scalar logs.",
+    )
+    metric_depth: MetricDepthLossConfig = DATACLASS_FIELD(
+        MetricDepthLossConfig(),
+        display_name="metric depth loss",
+        description="""
+        Hyper parameters for the metric-depth loss. Shared by both variants,
+        which supervise the same metric scale head.""",
+    )
+    panoptic: PanopticLossConfig = DATACLASS_FIELD(
+        PanopticLossConfig(),
+        display_name="panoptic losses",
+        description="Loss weights for the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningLossConfig = DATACLASS_FIELD(
+        ReasoningLossConfig(),
+        display_name="reasoning losses",
+        description="Loss weights for the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_core/microservices/constants.py
+++ b/nvidia_tao_core/microservices/constants.py
@@ -7,7 +7,7 @@ TAO_NETWORKS = set([
     "action_recognition", "bevfusion", "classification_pyt", "grounding_dino", "mal", "mask2former",
     "mask_grounding_dino", "ml_recog", "ocdnet", "ocrnet", "optical_inspection", "pointpillars",
     "pose_classification", "re_identification", "centerpose", "visual_changenet_classify",
-    "visual_changenet_segment", "deformable_detr",
+    "visual_changenet_segment", "deformable_detr", "nvpanoptix3d_v2",
     "depth_net_mono", "depth_net_stereo", "dino", "nvpanoptix3d", "rtdetr", "segformer",  # PYT CV MODELS
     "annotations", "analytics", "augmentation", "auto_label", "image"  # Data_Service tasks.
 ])
@@ -24,6 +24,7 @@ _PYT_TAO_NETWORKS = set([
     "action_recognition", "bevfusion", "depth_net_mono", "depth_net_stereo", "deformable_detr", "dino",
     "grounding_dino", "mask_grounding_dino", "mal", "mask2former", "ml_recog", "ocdnet", "ocrnet", "optical_inspection",
     "pointpillars", "pose_classification", "re_identification", "rtdetr", "centerpose", "segformer",
+    "nvpanoptix3d_v2",
     "visual_changenet_classify", "visual_changenet_segment"
 ])
 _DATA_SERVICES_ACTIONS = set([
@@ -45,7 +46,7 @@ BACKBONE_AND_FULL_MODEL_PTM_SUPPORTING_NETWORKS = set([
     "dino", "grounding_dino", "mask_grounding_dino", "classification_pyt"
 ])
 
-AUTOML_DISABLED_NETWORKS = ["mal", "nvpanoptix3d"]  # These networks can't support AutoML
+AUTOML_DISABLED_NETWORKS = ["mal", "nvpanoptix3d", "nvpanoptix3d_v2"]  # These networks can't support AutoML
 TENSORBOARD_DISABLED_NETWORKS = [
     'classification_pyt',
 ]  # These networks currently don't produce tfevents logs as they are third party models
@@ -86,6 +87,7 @@ NETWORK_CONTAINER_MAPPING = {"action_recognition": "TAO_PYTORCH",
                              "grounding_dino": "TAO_PYTORCH",
                              "image": "TAO_DS",
                              "mal": "TAO_PYTORCH",
+                             "nvpanoptix3d_v2": "TAO_PYTORCH",
                              "mask2former": "TAO_PYTORCH",
                              "mask_grounding_dino": "TAO_PYTORCH",
                              "ml_recog": "TAO_PYTORCH",

--- a/nvidia_tao_core/microservices/handlers/network_configs/nvpanoptix3d_v2.config.json
+++ b/nvidia_tao_core/microservices/handlers/network_configs/nvpanoptix3d_v2.config.json
@@ -1,0 +1,267 @@
+{
+    "api_params": {
+        "dataset_type": "nvpanoptix3d_v2",
+        "actions": [
+            "train",
+            "evaluate",
+            "export",
+            "inference"
+        ],
+        "formats": [
+            "scannetpp",
+            "reasoning_jsonl"
+        ],
+        "accepted_ds_intents": [
+            "training",
+            "evaluation",
+            "testing"
+        ],
+        "image": "TAO_PYTORCH",
+        "spec_backend": "yaml",
+        "actions_pipe": {
+            "train": "train",
+            "evaluate": "evaluate",
+            "export": "export_with_spec",
+            "inference": "inference"
+        }
+    },
+    "dataset_validation": {
+        "required_files": {
+            "scannetpp": [
+                {
+                    "all_of": [
+                        {
+                            "path": "categories.json",
+                            "type": "file"
+                        },
+                        {
+                            "path": "all_metadata.npz",
+                            "type": "file"
+                        },
+                        {
+                            "path": ".",
+                            "type": "regex",
+                            "regex": "*/images/*.jpg"
+                        },
+                        {
+                            "path": ".",
+                            "type": "regex",
+                            "regex": "*/panoptic/*.png"
+                        },
+                        {
+                            "path": ".",
+                            "type": "regex",
+                            "regex": "*/depth/*.png"
+                        }
+                    ]
+                }
+            ],
+            "reasoning_jsonl": [
+                {
+                    "path": "manifest.jsonl",
+                    "type": "file"
+                }
+            ]
+        }
+    },
+    "dynamic_config": {
+        "model_type_key": "model.model_type",
+        "rules": {
+            "panoptic": {
+                "remove": [
+                    "model.reasoning",
+                    "dataset.reasoning",
+                    "train.reasoning",
+                    "inference.save_full_point_cloud"
+                ]
+            },
+            "reasoning": {
+                "remove": [
+                    "model.panoptic",
+                    "dataset.panoptic",
+                    "train.panoptic",
+                    "evaluate.cls_threshold",
+                    "evaluate.overlap_threshold",
+                    "inference.cls_threshold",
+                    "inference.overlap_threshold",
+                    "inference.categories_json",
+                    "export"
+                ]
+            }
+        }
+    },
+    "data_sources": {
+        "train": {
+            "dataset.panoptic.train_preprocessed_root": {
+                "source": "train_datasets",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.panoptic.val_preprocessed_root": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.reasoning.train_manifest": {
+                "source": "train_datasets",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            },
+            "dataset.reasoning.val_manifest": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            }
+        },
+        "evaluate": {
+            "dataset.panoptic.train_preprocessed_root": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.panoptic.val_preprocessed_root": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.reasoning.train_manifest": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            },
+            "dataset.reasoning.val_manifest": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            }
+        },
+        "export": {
+            "export.categories_json": {
+                "source": "eval_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": "categories.json",
+                "optional": true
+            }
+        },
+        "inference": {
+            "dataset.panoptic.train_preprocessed_root": {
+                "source": "inference_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.panoptic.val_preprocessed_root": {
+                "source": "inference_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "scannetpp"
+                },
+                "path": ""
+            },
+            "dataset.reasoning.train_manifest": {
+                "source": "inference_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            },
+            "dataset.reasoning.val_manifest": {
+                "source": "inference_dataset",
+                "multiple_sources": false,
+                "conditional": {
+                    "metadata_key": "format",
+                    "equals": "reasoning_jsonl"
+                },
+                "path": "manifest.jsonl"
+            }
+        }
+    },
+    "cloud_upload": {
+        "upload_strategy": {
+            "inference": "tarball_after_completion"
+        },
+        "retain_patterns": {
+            "train": [
+                ".*\\.pth$"
+            ]
+        }
+    },
+    "spec_params": {
+        "train": {
+            "results_dir": "output_dir",
+            "model.backbone.pretrained_backbone_path": "ptm_if_no_resume_model",
+            "train.resume_training_checkpoint_path": "resume_model",
+            "encryption_key": "key"
+        },
+        "evaluate": {
+            "results_dir": "output_dir",
+            "evaluate.checkpoint": "parent_model",
+            "encryption_key": "key"
+        },
+        "export": {
+            "results_dir": "output_dir",
+            "export.checkpoint": "parent_model",
+            "export.onnx_file": "create_onnx_file",
+            "encryption_key": "key"
+        },
+        "inference": {
+            "results_dir": "output_dir",
+            "inference.checkpoint": "parent_model",
+            "encryption_key": "key"
+        }
+    },
+    "metrics": {
+        "available_metrics": [
+            "val/mAP",
+            "val/mAP50",
+            "val/mAP25",
+            "val/mIoU"
+        ],
+        "monitoring_metric": "val/mAP",
+        "dynamic_metric_patterns": [
+            "^(train|val)/loss(_[A-Za-z0-9_]+)?$"
+        ]
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->

This PR adds TAO Core configuration and microservice registration for the `nvpanoptix3d_v2` network.

The main changes are:

- Add the `nvidia_tao_core.config.nvpanoptix3d_v2` configuration package, including schemas for model, dataset, training, evaluation, inference, and export.
- Support the `panoptic` and `reasoning` model variants through `model.model_type`.
- Align the TAO Core dataclasses with the current TAO PyTorch configuration surface, excluding redundant or unsupported options and exposing only fields consumed by the runtime.
- Reuse existing common TAO configuration classes for shared train, evaluation, inference, export, checkpoint, and experiment settings.
- Add model-specific schemas for:
  - The shared VGGT backbone and metric-depth head.
  - DINOv2/VGGT feature fusion, the panoptic decoder, and the LoftUp upscaler.
  - The Qwen reasoner, LoRA adapters, SAM3, and the segmentation prompt projector.
- Add ScanNet++ panoptic and JSONL reasoning dataset configurations.
- Add model-type-aware dynamic configuration rules so irrelevant panoptic or reasoning fields are hidden.
- Add dataset validation and data-source mappings for ScanNet++ and reasoning JSONL datasets.
- Register `nvpanoptix3d_v2` as a TAO PyTorch network and map it to the `TAO_PYTORCH` container.
- Disable AutoML for this network because it is not currently supported.
- Add microservice action mappings for training, evaluation, inference, and supported export workflows.


### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->

This change provides the TAO Core integration required to configure and launch NVPanoptix3Dv2 workflows consistently with other TAO PyTorch networks.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->
JIRA: TAOVN-1251

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->
Yes, add `nvpanoptix3d_v2` configs

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

The pre-commit checks were run against the complete branch diff:

```console
$ pre-commit run --from-ref origin/main --to-ref HEAD

TruffleHog secret scan...................................................Passed
dependency change guard..............................(no files to check)Skipped
license header...........................................................Passed
pylint...................................................................Passed
pydocstyle...............................................................Passed
flake8...................................................................Passed
```

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->
Yes — portions were co-authored with an AI coding assistant.

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added TAO Core configuration and microservice support for the NVPanoptix3Dv2 panoptic and reasoning workflows.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [ ] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->


