### PR TITLE
feat(cosmos-rl): expose DAFT vision sampling options

### DIFF
--- a/nvidia_tao_core/config/cosmos-rl/evaluate.py
+++ b/nvidia_tao_core/config/cosmos-rl/evaluate.py
@@ -221,34 +221,118 @@ class EvaluationConfig:
 
 @dataclass
 class VisionConfig:
-    """Vision config."""
+    """Vision options forwarded to the Cosmos-RL media loader."""
 
-    fps: int = INT_FIELD(
+    fps: Optional[float] = FLOAT_FIELD(
         value=None,
         default_value=None,
-        valid_min=1,
-        valid_max=3,
+        valid_min=0.01,
+        valid_max="inf",
         display_name="FPS",
-        description="Frames per second for vision processing.",
+        description=(
+            "Frames per second sampled from each video. Mutually exclusive "
+            "with nframes. min_frames and max_frames apply only in FPS mode."
+        ),
         automl_enabled="TRUE"
     )
 
-    total_pixels: int = INT_FIELD(
+    nframes: Optional[int] = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Number of frames",
+        description=(
+            "Number of frames sampled uniformly from each video. Mutually "
+            "exclusive with fps."
+        )
+    )
+
+    min_frames: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Minimum frames",
+        description="Minimum sampled frames per video when fps is used."
+    )
+
+    max_frames: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Maximum frames",
+        description="Maximum sampled frames per video when fps is used."
+    )
+
+    video_start: Optional[float] = FLOAT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=0.0,
+        valid_max="inf",
+        display_name="Video start",
+        description="Optional start time in seconds for video sampling."
+    )
+
+    video_end: Optional[float] = FLOAT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=0.0,
+        valid_max="inf",
+        display_name="Video end",
+        description="Optional end time in seconds for video sampling."
+    )
+
+    resized_height: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Resized height",
+        description=(
+            "Explicit resized video-frame height. Set together with "
+            "resized_width."
+        )
+    )
+
+    resized_width: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Resized width",
+        description=(
+            "Explicit resized video-frame width. Set together with "
+            "resized_height."
+        )
+    )
+
+    min_pixels: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Minimum pixels",
+        description="Minimum per-frame pixel budget for vision processing."
+    )
+
+    max_pixels: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Maximum pixels",
+        description="Maximum per-frame pixel budget for vision processing."
+    )
+
+    total_pixels: Optional[int] = INT_FIELD(
         value=None,
         default_value=None,
         valid_min=1,
         valid_max="inf",
         display_name="Total pixels",
         description="Total number of pixels for vision processing."
-    )
-
-    nframes: int = INT_FIELD(
-        value=8,
-        default_value=8,
-        valid_min=1,
-        valid_max=8,
-        display_name="Number of frames",
-        description="Number of frames for vision processing."
     )
 
 

--- a/nvidia_tao_core/config/cosmos-rl/inference.py
+++ b/nvidia_tao_core/config/cosmos-rl/inference.py
@@ -41,7 +41,18 @@ class InferenceConfig:
         default_value=4,
         value=4,
         display_name="FPS",
-        description="FPS for inference"
+        description="FPS for inference. Mutually exclusive with num_frames."
+    )
+    num_frames: Optional[int] = INT_FIELD(
+        default_value=None,
+        value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Number of frames",
+        description=(
+            "Uniformly sample this many frames from each video. Mutually "
+            "exclusive with fps."
+        )
     )
     total_pixels: Optional[int] = INT_FIELD(
         default_value=6422528,

--- a/nvidia_tao_core/config/cosmos-rl/train.py
+++ b/nvidia_tao_core/config/cosmos-rl/train.py
@@ -702,34 +702,118 @@ class PolicyConfig:
 
 @dataclass
 class VisionConfig:
-    """Vision config."""
+    """Vision options forwarded to the Cosmos-RL/DAFT media loader."""
 
-    fps: int = INT_FIELD(
+    fps: Optional[float] = FLOAT_FIELD(
         value=None,
         default_value=None,
-        valid_min=1,
-        valid_max=3,
+        valid_min=0.01,
+        valid_max="inf",
         display_name="FPS",
-        description="Frames per second for vision processing.",
+        description=(
+            "Frames per second sampled from each video. Mutually exclusive "
+            "with nframes. min_frames and max_frames apply only in FPS mode."
+        ),
         automl_enabled="TRUE"
     )
 
-    total_pixels: int = INT_FIELD(
+    nframes: Optional[int] = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Number of frames",
+        description=(
+            "Number of frames sampled uniformly from each video. Mutually "
+            "exclusive with fps."
+        )
+    )
+
+    min_frames: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Minimum frames",
+        description="Minimum sampled frames per video when fps is used."
+    )
+
+    max_frames: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Maximum frames",
+        description="Maximum sampled frames per video when fps is used."
+    )
+
+    video_start: Optional[float] = FLOAT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=0.0,
+        valid_max="inf",
+        display_name="Video start",
+        description="Optional start time in seconds for video sampling."
+    )
+
+    video_end: Optional[float] = FLOAT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=0.0,
+        valid_max="inf",
+        display_name="Video end",
+        description="Optional end time in seconds for video sampling."
+    )
+
+    resized_height: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Resized height",
+        description=(
+            "Explicit resized video-frame height. Set together with "
+            "resized_width."
+        )
+    )
+
+    resized_width: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Resized width",
+        description=(
+            "Explicit resized video-frame width. Set together with "
+            "resized_height."
+        )
+    )
+
+    min_pixels: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Minimum pixels",
+        description="Minimum per-frame pixel budget for vision processing."
+    )
+
+    max_pixels: Optional[int] = INT_FIELD(
+        value=None,
+        default_value=None,
+        valid_min=1,
+        valid_max="inf",
+        display_name="Maximum pixels",
+        description="Maximum per-frame pixel budget for vision processing."
+    )
+
+    total_pixels: Optional[int] = INT_FIELD(
         value=None,
         default_value=None,
         valid_min=1,
         valid_max="inf",
         display_name="Total pixels",
         description="Total number of pixels for vision processing."
-    )
-
-    nframes: int = INT_FIELD(
-        value=8,
-        default_value=8,
-        valid_min=1,
-        valid_max=8,
-        display_name="Number of frames",
-        description="Number of frames for vision processing."
     )
 
 

--- a/nvidia_tao_core/tests/test_cosmos_rl_vision_config.py
+++ b/nvidia_tao_core/tests/test_cosmos_rl_vision_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Cosmos-RL vision configuration exposure."""
+
+from dataclasses import fields
+import importlib
+
+from nvidia_tao_core.api_utils import dataclass2json_converter
+
+
+TRAIN_AND_EVALUATE_VISION_FIELDS = {
+    "fps",
+    "nframes",
+    "min_frames",
+    "max_frames",
+    "video_start",
+    "video_end",
+    "resized_height",
+    "resized_width",
+    "min_pixels",
+    "max_pixels",
+    "total_pixels",
+}
+
+
+def _module(action):
+    return importlib.import_module(f"nvidia_tao_core.config.cosmos-rl.{action}")
+
+
+def _schema_properties(action, *path):
+    module = _module(action)
+    schema = dataclass2json_converter.create_json_schema(
+        dataclass2json_converter.dataclass_to_json(module.ExperimentConfig())
+    )
+    properties = schema["properties"]
+    for part in path:
+        properties = properties[part]["properties"]
+    return properties
+
+
+def test_train_exposes_daft_vision_options():
+    names = {field.name for field in fields(_module("train").VisionConfig)}
+    assert TRAIN_AND_EVALUATE_VISION_FIELDS <= names
+
+
+def test_evaluate_exposes_daft_vision_options():
+    names = {field.name for field in fields(_module("evaluate").VisionConfig)}
+    assert TRAIN_AND_EVALUATE_VISION_FIELDS <= names
+
+
+def test_inference_exposes_runtime_num_frames_option():
+    names = {field.name for field in fields(_module("inference").InferenceConfig)}
+    assert {"fps", "num_frames", "total_pixels"} <= names
+
+
+def test_generated_train_and_evaluate_schemas_expose_daft_vision_options():
+    train = _schema_properties("train", "custom", "vision")
+    evaluate = _schema_properties("evaluate", "evaluate", "vision")
+
+    assert TRAIN_AND_EVALUATE_VISION_FIELDS <= train.keys()
+    assert TRAIN_AND_EVALUATE_VISION_FIELDS <= evaluate.keys()
+    assert train["fps"]["type"] == evaluate["fps"]["type"] == "float"
+    assert train["max_frames"]["type"] == evaluate["max_frames"]["type"] == "int"
+
+
+def test_generated_inference_schema_exposes_num_frames():
+    inference = _schema_properties("inference", "inference")
+    assert inference["num_frames"]["type"] == "int"


### PR DESCRIPTION
## What changed

- expose the complete Cosmos-RL/DAFT video sampling and spatial preprocessing surface in the train and evaluate vision dataclasses
- document the `fps`/`nframes` mutual exclusion and FPS-only `min_frames`/`max_frames` bounds
- expose the existing inference runtime's `num_frames` option
- add focused dataclass and generated-schema coverage

## Why

The source-baked DAFT training hook and Qwen video reader accept FPS sampling, frame bounds, time clipping, explicit resize dimensions, and pixel bounds, but TAO Core declared only `fps`, `nframes`, and `total_pixels`. Generated consumers therefore could not discover or configure supported runtime behavior such as `fps=1` with `max_frames=120`.

## User impact

TAO schema consumers can discover the native vision options and generate matching Cosmos-RL configuration instead of relying on undocumented overrides. `nframes` is no longer artificially limited to 8 in the metadata.

## Validation

- `python -m pytest -q nvidia_tao_core/tests/test_cosmos_rl_vision_config.py`
- `python -m flake8 --ignore=E24,W504 --max-line-length=120 nvidia_tao_core/config/cosmos-rl/train.py nvidia_tao_core/config/cosmos-rl/evaluate.py nvidia_tao_core/config/cosmos-rl/inference.py nvidia_tao_core/tests/test_cosmos_rl_vision_config.py`
- `git diff --check`
