### PR TITLE
[TLT-5931][Bugfix] Align DINOv3 schema config with runtime

### DIFF
--- a/nvidia_tao_core/config/dinov3/default_config.py
+++ b/nvidia_tao_core/config/dinov3/default_config.py
@@ -10,15 +10,16 @@ subclassing the nvdinov2 dataclasses. Only the genuinely new pieces are added he
 * a v3 ``map_params`` table with **patch-16** ViT entries (vit_s, vit_s_plus, vit_b, vit_l,
   vit_h_plus, vit_7b),
 * RoPE backbone fields (``rope_theta`` etc.) and patch-16 defaults,
-* a ``GramConfig`` for Gram anchoring (wired up in a later step), and
-* a disabled ``lora`` stub for forward-compatibility.
+* a ``GramConfig`` for Gram anchoring, and
+* ``LoRAConfig`` / ``PreservationConfig`` for parameter-efficient, geometry-preserving
+  continual pre-training.
 
 DINOv3 is Meta IP implemented inside TAO; the family/endpoint is named ``dinov3``
 (not ``nvdinov3``). ``nvdinov2`` stays frozen.
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from omegaconf import MISSING
 
@@ -27,6 +28,7 @@ from nvidia_tao_core.config.utils.types import (
     INT_FIELD,
     FLOAT_FIELD,
     BOOL_FIELD,
+    LIST_FIELD,
     DATACLASS_FIELD,
 )
 from nvidia_tao_core.config.nvdinov2.default_config import (
@@ -269,36 +271,104 @@ class GramConfig:
 
 @dataclass
 class LoRAConfig:
-    """Disabled LoRA stub for forward-compatibility (parameter-efficient SSL, Phase 2)."""
+    """LoRA config for parameter-efficient continual pre-training.
+
+    When enabled, the targeted projections of the student and EMA-teacher backbones are
+    replaced by key-preserving LoRA layers. Adapters are folded into the base weights on
+    conversion and export, so the resulting artifact is a stock DINOv3 backbone.
+    """
 
     enable: bool = BOOL_FIELD(
         value=False,
         default_value=False,
-        description="Whether to apply LoRA adapters (disabled in v1)",
+        description="Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
         display_name="enable lora",
-        popular="no"
+        popular="yes"
     )
     rank: int = INT_FIELD(
         value=8,
         default_value=8,
         valid_min=1,
         valid_max="inf",
-        description="LoRA rank",
+        description="LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
         display_name="lora rank",
-        popular="no"
+        popular="yes"
     )
     alpha: float = FLOAT_FIELD(
         value=16.0,
         default_value=16.0,
-        description="LoRA scaling alpha",
+        description="LoRA scaling alpha; the applied scale is alpha / rank.",
         display_name="lora alpha",
+        popular="yes"
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        description="Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+        display_name="lora dropout",
         popular="no"
+    )
+    target_modules: List[str] = LIST_FIELD(
+        arrList=["qkv", "proj"],
+        default_value=["qkv", "proj"],
+        description=(
+            "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the "
+            "attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. "
+            "SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1."
+        ),
+        display_name="lora target modules",
+        popular="yes"
+    )
+    num_last_blocks: int = INT_FIELD(
+        value=0,
+        default_value=0,
+        valid_min=0,
+        valid_max="inf",
+        description="Adapt only the last N transformer blocks. 0 = all blocks.",
+        display_name="lora num last blocks",
+        popular="yes"
+    )
+
+
+@dataclass
+class PreservationConfig:
+    """CLS-token preservation against the frozen anchor teacher."""
+
+    enable: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Whether to add CLS-token preservation losses against the frozen anchor teacher. "
+            "Recommended alongside LoRA for continual pre-training."
+        ),
+        display_name="enable preservation",
+        popular="yes"
+    )
+    cls_mse_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max="inf",
+        description="Weight of the CLS-token MSE preservation term (0 disables just this term).",
+        display_name="cls mse weight",
+        popular="yes"
+    )
+    cls_cosine_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max="inf",
+        description="Weight of the CLS-token cosine preservation term (0 disables just this term).",
+        display_name="cls cosine weight",
+        popular="yes"
     )
 
 
 @dataclass
 class DINOv3ModelConfig:
-    """DINOv3 model config (reuses nvdinov2 distill/head, adds gram + lora)."""
+    """DINOv3 model config with Gram, LoRA, and preservation options."""
 
     centering_method: str = STR_FIELD(
         value="sinkhorn",
@@ -330,7 +400,11 @@ class DINOv3ModelConfig:
     )
     lora: LoRAConfig = DATACLASS_FIELD(
         LoRAConfig(),
-        description="Disabled LoRA stub for forward-compatibility"
+        description="Configuration for LoRA parameter-efficient continual pre-training"
+    )
+    preservation: PreservationConfig = DATACLASS_FIELD(
+        PreservationConfig(),
+        description="Configuration for CLS-token preservation against the frozen anchor teacher"
     )
 
 
@@ -426,6 +500,14 @@ class DINOv3TrainExpConfig(NVDINOv2TrainExpConfig):
         ),
         display_name="distributed strategy",
         popular="yes"
+    )
+    log_every_n_steps: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        description="Number of training steps between logger updates.",
+        display_name="logging interval",
+        popular="no",
     )
     cudnn: DINOv3CuDNNConfig = DATACLASS_FIELD(
         DINOv3CuDNNConfig(),

--- a/nvidia_tao_core/tests/dinov3/test_config.py
+++ b/nvidia_tao_core/tests/dinov3/test_config.py
@@ -8,6 +8,10 @@ schemas in tao-skills-external and must stay aligned with
 ``nvidia_tao_pytorch.config.dinov3.default_config`` (bug 6465432).
 """
 
+from dataclasses import asdict, fields
+
+import pytest
+
 from nvidia_tao_core.api_utils.dataclass2json_converter import (
     create_json_schema,
     dataclass_to_json,
@@ -88,6 +92,26 @@ def test_lora_and_preservation_schema_match_runtime_config():
     assert set(model["preservation"]["properties"]) == {
         "enable", "cls_mse_weight", "cls_cosine_weight"
     }
+
+
+@pytest.mark.parametrize(
+    ("config_name", "core_config"),
+    (("LoRAConfig", LoRAConfig), ("PreservationConfig", PreservationConfig)),
+)
+def test_adaptation_defaults_match_tao_pytorch_when_available(
+    config_name, core_config
+):
+    """Keep tao-core's schema source aligned with the optional runtime package."""
+    runtime = pytest.importorskip(
+        "nvidia_tao_pytorch.config.dinov3.default_config",
+        reason="tao-pytorch is not installed in tao-core-only environments",
+    )
+    runtime_config = getattr(runtime, config_name)
+
+    assert [field.name for field in fields(core_config)] == [
+        field.name for field in fields(runtime_config)
+    ]
+    assert asdict(core_config()) == asdict(runtime_config())
 
 
 def test_pretrained_model_path_description_is_dinov3_specific():

--- a/nvidia_tao_core/tests/dinov3/test_config.py
+++ b/nvidia_tao_core/tests/dinov3/test_config.py
@@ -18,6 +18,8 @@ from nvidia_tao_core.config.dinov3.default_config import (
     DINOv3TrainExpConfig,
     DINOv3TransformConfig,
     ExperimentConfig,
+    LoRAConfig,
+    PreservationConfig,
     SUPPORTED_BACKBONES,
     SUPPORTED_IMAGE_SIZES,
     map_params,
@@ -58,6 +60,34 @@ def test_cudnn_defaults_match_dinov3_templates():
     assert cudnn["properties"]["deterministic"]["default"] is False
     assert cudnn["properties"]["deterministic"]["description"]
     assert cudnn["properties"]["deterministic"]["title"] == "CuDNN deterministic"
+
+
+def test_logging_interval_defaults_to_every_step():
+    """Short DINOv3 runs publish component losses without extra overrides."""
+    config = ExperimentConfig()
+    assert config.train.log_every_n_steps == 1
+
+    field = DINOv3TrainExpConfig.__dataclass_fields__["log_every_n_steps"]
+    assert field.metadata["valid_min"] == 1
+    schema = create_json_schema(dataclass_to_json(config))
+    logging_interval = schema["properties"]["train"]["properties"]["log_every_n_steps"]
+    assert logging_interval["default"] == 1
+
+
+def test_lora_and_preservation_schema_match_runtime_config():
+    """Generated schemas expose the complete runtime adaptation controls."""
+    config = ExperimentConfig()
+    assert config.model.lora == LoRAConfig()
+    assert config.model.preservation == PreservationConfig()
+
+    schema = create_json_schema(dataclass_to_json(config))
+    model = schema["properties"]["model"]["properties"]
+    assert set(model["lora"]["properties"]) == {
+        "enable", "rank", "alpha", "dropout", "target_modules", "num_last_blocks"
+    }
+    assert set(model["preservation"]["properties"]) == {
+        "enable", "cls_mse_weight", "cls_cosine_weight"
+    }
 
 
 def test_pretrained_model_path_description_is_dinov3_specific():


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Replace the disabled DINOv3 LoRA schema stub with the complete runtime configuration.
- Add the DINOv3 CLS-token preservation configuration.
- Expose `train.log_every_n_steps` with an every-step default for short-run observability.
- Extend schema tests to cover logging cadence, all LoRA fields, and preservation fields.

### Why are the changes needed?

`tao-core` is the source of truth used to generate TAO skill schemas. Its DINOv3 configuration had drifted behind `tao-pytorch`: generated schemas described LoRA as disabled, omitted supported LoRA controls and preservation entirely, and could not expose the runtime logging cadence. Keeping these dataclasses aligned prevents regeneration from restoring stale schema output.

### Related issues

- [TLT-5931](https://jirasw.nvidia.com/browse/TLT-5931) / [NVBug 6641991](https://nvbugs.nvidia.com/bug/6641991)
- [TLT-5942](https://jirasw.nvidia.com/browse/TLT-5942) / [NVBug 6642016](https://nvbugs.nvidia.com/bug/6642016)

### Does this PR introduce _any_ user-facing change?

Yes. Generated DINOv3 schemas now expose the supported LoRA, preservation, and logging-cadence controls.

### How was this patch tested?

Using the ARM64 image pinned by `tao-pytorch`:

```text
python -m pytest -q \
  nvidia_tao_core/tests/dinov3/test_config.py \
  nvidia_tao_core/tests/test_downstream_dinov3_backbones.py

14 passed
```

The configured static checks also passed:

```text
license header: Passed
pylint: 10.00/10
pydocstyle: Passed
flake8: Passed
git diff --check: Passed
Python compilation: Passed
```

`nvidia_tao_core/tests/scripts/test_generate_schema.py` could not collect in that image because its optional Kubernetes test dependency is absent. Hosted `/build` CI is requested below to run the repository-complete environment.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

DINOv3 generated schemas now match the runtime LoRA and preservation configuration and expose per-step logging cadence.

### Checklist

- [X] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [X] I have read the contributing guidelines
- [X] The code follows the project's style, and lint and format checks pass locally
- [X] I added or updated tests covering this change
- [ ] All tests pass locally; the repository-complete suite is delegated to `/build`
- [X] I added or updated documentation (schema metadata and docstrings)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [X] No secrets, credentials, proprietary data, or customer data are included in this PR
- [X] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

This is the schema-source dependency for the companion `tao-pytorch` runtime PR and the subsequent `tao-skill-bank` schema regeneration. Please review the DINOv3 dataclass parity and generated-schema assertions first.
