### PR TITLE
[TAO-1796][Feature] clip: add LoRA fine-tuning schema with per-tower modes

### DIFF
--- a/nvidia_tao_core/config/clip/default_config.py
+++ b/nvidia_tao_core/config/clip/default_config.py
@@ -110,30 +110,19 @@ class CLIPModelConfig:
 class CLIPLoRATargetConfig:
     """Adaptation configuration for a single encoder tower (vision or text).
 
-    Controls how a tower is adapted. ``mode: legacy`` preserves existing
-    enabled-only YAMLs by resolving ``enabled: true`` to ``lora`` and
-    ``enabled: false`` to ``frozen``.
+    Controls whether a tower is frozen, fully trainable, or adapted with LoRA.
     """
 
     mode: str = STR_FIELD(
-        value="legacy",
-        default_value="legacy",
-        valid_options="legacy,frozen,full,lora",
+        value="frozen",
+        default_value="frozen",
+        valid_options="frozen,full,lora",
         description=(
-            "Tower adaptation mode. 'legacy' resolves from the deprecated "
-            "enabled field; 'frozen' leaves the tower fixed; 'full' trains "
-            "all tower parameters; 'lora' trains only injected LoRA parameters."
+            "Tower adaptation mode. 'frozen' leaves the tower fixed; 'full' "
+            "trains all tower parameters; 'lora' trains only injected LoRA "
+            "parameters."
         ),
         display_name="Adaptation Mode",
-    )
-    enabled: Optional[bool] = BOOL_FIELD(
-        value=None,
-        default_value=None,
-        description=(
-            "Deprecated legacy switch. With mode='legacy', true selects LoRA "
-            "and false selects frozen. Omit it when using an explicit mode."
-        ),
-        display_name="Enabled (Legacy)",
     )
     target_modules: List[str] = LIST_FIELD(
         arrList=["q_proj", "k_proj", "v_proj", "out_proj"],

--- a/nvidia_tao_core/config/clip/default_config.py
+++ b/nvidia_tao_core/config/clip/default_config.py
@@ -104,6 +104,156 @@ class CLIPModelConfig:
 
 
 # =============================================================================
+# PEFT Config
+# =============================================================================
+@dataclass
+class CLIPLoRATargetConfig:
+    """Adaptation configuration for a single encoder tower (vision or text).
+
+    Controls how a tower is adapted. ``mode: legacy`` preserves existing
+    enabled-only YAMLs by resolving ``enabled: true`` to ``lora`` and
+    ``enabled: false`` to ``frozen``.
+    """
+
+    mode: str = STR_FIELD(
+        value="legacy",
+        default_value="legacy",
+        valid_options="legacy,frozen,full,lora",
+        description=(
+            "Tower adaptation mode. 'legacy' resolves from the deprecated "
+            "enabled field; 'frozen' leaves the tower fixed; 'full' trains "
+            "all tower parameters; 'lora' trains only injected LoRA parameters."
+        ),
+        display_name="Adaptation Mode",
+    )
+    enabled: Optional[bool] = BOOL_FIELD(
+        value=None,
+        default_value=None,
+        description=(
+            "Deprecated legacy switch. With mode='legacy', true selects LoRA "
+            "and false selects frozen. Omit it when using an explicit mode."
+        ),
+        display_name="Enabled (Legacy)",
+    )
+    target_modules: List[str] = LIST_FIELD(
+        arrList=["q_proj", "k_proj", "v_proj", "out_proj"],
+        default_value=["q_proj", "k_proj", "v_proj", "out_proj"],
+        description="Module leaf names to target for LoRA injection. "
+                    "SigLIP2: 'q_proj', 'k_proj', 'v_proj', 'out_proj'. "
+                    "RADIO: 'qkv', 'proj' (fused attention). OpenCLIP uses "
+                    "nn.MultiheadAttention and does not support LoRA mode yet; "
+                    "use mode 'full' or 'frozen'.",
+        display_name="Target Modules",
+    )
+    num_last_blocks: int = INT_FIELD(
+        value=3,
+        default_value=3,
+        valid_min=0,
+        description="Number of final transformer blocks to adapt. "
+                    "0 means adapt all blocks.",
+        display_name="Number of Last Blocks",
+    )
+    rank: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        description="LoRA rank (low-rank dimension).",
+        display_name="Rank",
+    )
+    alpha: int = INT_FIELD(
+        value=16,
+        default_value=16,
+        valid_min=1,
+        description="LoRA alpha scaling factor. Effective scale = alpha / rank.",
+        display_name="Alpha",
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        description="Dropout applied to LoRA input.",
+        display_name="Dropout",
+    )
+
+
+@dataclass
+class CLIPPEFTConfig:
+    """Parameter-efficient fine-tuning configuration for CLIP."""
+
+    enabled: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Enable PEFT mode. When False, training uses standard "
+                    "full fine-tuning (existing behavior).",
+        display_name="Enabled",
+    )
+    method: str = STR_FIELD(
+        value="lora",
+        default_value="lora",
+        valid_options="lora",
+        description="PEFT method. Currently only 'lora' is supported.",
+        display_name="Method",
+    )
+    train_logit_calibration: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        description=(
+            "Train logit_scale and optional logit_bias while PEFT is enabled. "
+            "Defaults to True to preserve existing LoRA behavior."
+        ),
+        display_name="Train Logit Calibration",
+    )
+    vision: CLIPLoRATargetConfig = DATACLASS_FIELD(
+        CLIPLoRATargetConfig(),
+        description="LoRA configuration for the vision encoder.",
+    )
+    text: CLIPLoRATargetConfig = DATACLASS_FIELD(
+        CLIPLoRATargetConfig(),
+        description="LoRA configuration for the text encoder.",
+    )
+
+
+# =============================================================================
+# Regularization Config
+# =============================================================================
+@dataclass
+class CLIPRegularizationConfig:
+    """Geometry-preserving regularization for domain adaptation."""
+
+    enabled: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Enable preservation regularization. When False, "
+                    "only the contrastive loss is used (existing behavior).",
+        display_name="Enabled",
+    )
+    embedding_mse_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        description="Weight for MSE loss between student and teacher embeddings.",
+        display_name="Embedding MSE Weight",
+    )
+    cosine_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        description="Weight for cosine preservation loss between "
+                    "student and teacher embeddings.",
+        display_name="Cosine Weight",
+    )
+    similarity_weight: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        description="Weight for similarity matrix preservation loss "
+                    "(MSE between student and teacher image-text similarity matrices).",
+        display_name="Similarity Weight",
+    )
+
+
+# =============================================================================
 # Dataset Config
 # =============================================================================
 @dataclass
@@ -737,6 +887,16 @@ class CLIPExperimentConfig(CommonExperimentConfig):
     inference: CLIPInferenceEvalConfig = DATACLASS_FIELD(
         CLIPInferenceEvalConfig(),
         description="Inference config.",
+    )
+    peft: CLIPPEFTConfig = DATACLASS_FIELD(
+        CLIPPEFTConfig(),
+        description="Parameter-efficient fine-tuning config (LoRA). "
+                    "Disabled by default.",
+    )
+    regularization: CLIPRegularizationConfig = DATACLASS_FIELD(
+        CLIPRegularizationConfig(),
+        description="Geometry-preserving regularization config. "
+                    "Disabled by default.",
     )
     export: CLIPExportConfig = DATACLASS_FIELD(
         CLIPExportConfig(),

--- a/nvidia_tao_core/tests/scripts/test_generate_schema.py
+++ b/nvidia_tao_core/tests/scripts/test_generate_schema.py
@@ -139,15 +139,13 @@ def test_clip_peft_and_regularization_schema():
         tower = peft["properties"][tower_name]
         tower_default = peft_default[tower_name]
         assert tower["properties"]["mode"]["enum"] == [
-            "legacy",
             "frozen",
             "full",
             "lora",
         ]
-        assert tower["properties"]["mode"]["default"] == "legacy"
-        assert tower_default["mode"] == "legacy"
-        assert "enabled" in tower["properties"]
-        assert "default" not in tower["properties"]["enabled"]
+        assert tower["properties"]["mode"]["default"] == "frozen"
+        assert tower_default["mode"] == "frozen"
+        assert "enabled" not in tower["properties"]
         assert "enabled" not in tower_default
         assert "nn.MultiheadAttention" in tower["properties"]["target_modules"]["description"]
 

--- a/nvidia_tao_core/tests/scripts/test_generate_schema.py
+++ b/nvidia_tao_core/tests/scripts/test_generate_schema.py
@@ -124,6 +124,44 @@ def test_clip_train_metadata_masking_schema():
     assert "train.siglip_loss_dist_impl to be 'local' or 'gather'" in mask_mode["description"]
 
 
+def test_clip_peft_and_regularization_schema():
+    """CLIP train schema exposes tower adaptation and preservation options."""
+    schema = generate_schema("clip", "train")
+
+    peft = schema["properties"]["peft"]
+    peft_default = schema["default"]["peft"]
+    assert peft["properties"]["enabled"]["default"] is False
+    assert peft["properties"]["method"]["enum"] == ["lora"]
+    assert peft["properties"]["train_logit_calibration"]["default"] is True
+    assert peft_default["train_logit_calibration"] is True
+
+    for tower_name in ("vision", "text"):
+        tower = peft["properties"][tower_name]
+        tower_default = peft_default[tower_name]
+        assert tower["properties"]["mode"]["enum"] == [
+            "legacy",
+            "frozen",
+            "full",
+            "lora",
+        ]
+        assert tower["properties"]["mode"]["default"] == "legacy"
+        assert tower_default["mode"] == "legacy"
+        assert "enabled" in tower["properties"]
+        assert "default" not in tower["properties"]["enabled"]
+        assert "enabled" not in tower_default
+        assert "nn.MultiheadAttention" in tower["properties"]["target_modules"]["description"]
+
+    regularization = schema["properties"]["regularization"]
+    regularization_default = schema["default"]["regularization"]
+    assert regularization["properties"]["enabled"]["default"] is False
+    assert regularization_default == {
+        "enabled": False,
+        "embedding_mse_weight": 0.05,
+        "cosine_weight": 0.05,
+        "similarity_weight": 0.10,
+    }
+
+
 def test_clip_metadata_evaluation_schema():
     """CLIP schemas expose metadata-aware validation and evaluation options."""
     schema = generate_schema("clip", "evaluate")

--- a/nvidia_tao_core/tests/scripts/test_generate_schema.py
+++ b/nvidia_tao_core/tests/scripts/test_generate_schema.py
@@ -51,7 +51,7 @@ def get_network_actions(network_name):
         return ["train", "evaluate", "export", "inference"]
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             config = json.load(f)
         return config.get("api_params", {}).get("actions", ["train", "evaluate", "export", "inference"])
     except (json.JSONDecodeError, KeyError):


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add CLIP PEFT and geometry-preserving regularization configuration to the `tao-core` API schema.

The schema now exposes:

- Per-tower adaptation modes: `frozen`, `full`, and `lora`
- `mode` as the sole per-tower adaptation interface
- Vision and text tower LoRA parameters
- Optional logit calibration training
- Embedding, cosine, and similarity preservation weights
- Guidance that OpenCLIP does not currently support LoRA mode and should use `full` or `frozen`

Example:

```yaml
peft:
  enabled: true
  method: lora
  train_logit_calibration: true
  vision:
    mode: lora
    rank: 8
    alpha: 16
    num_last_blocks: 3
  text:
    mode: frozen

regularization:
  enabled: true
  embedding_mse_weight: 0.05
  cosine_weight: 0.05
  similarity_weight: 0.10
```

### Why are the changes needed?

The CLIP runtime in `tao-pytorch` supports LoRA and per-tower adaptation through NVIDIA-TAO/tao-pytorch#106, but the corresponding `tao-core` CLIP schema does not currently define `peft` or `regularization`.

As a result, API schema validation treats these supported settings as unknown and removes them from merged experiment specifications. Adding the corresponding schema definitions makes the API configuration consistent with the runtime and allows users to configure CLIP LoRA training through schema-driven interfaces.

### Related issues

Part of TAO-1796.

Companion to NVIDIA-TAO/tao-pytorch#106.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, the CLIP API schema did not expose `peft` or `regularization`, and schema cleanup removed those settings from experiment specifications.

After this change, users can configure per-tower CLIP adaptation, LoRA parameters, logit calibration, and preservation regularization through the API schema.

The pre-release tower-level `enabled` field and `legacy` mode were removed because this interface has not appeared in a released TAO version. `mode` is now the sole per-tower interface. Internal configurations using the earlier interface must replace tower-level `enabled: true` with `mode: lora` and `enabled: false` with `mode: frozen`. The top-level `peft.enabled` switch remains unchanged, and no released TAO configuration requires migration.

OpenCLIP LoRA is not supported yet; OpenCLIP users should select `full` or `frozen` mode.

### How was this patch tested?

Added focused schema coverage for:

- Presence and defaults of `peft` and `regularization`
- Valid tower modes: `frozen`, `full`, and `lora`
- `frozen` defaults for both towers
- Absence of tower-level `enabled`
- Logit calibration defaults
- OpenCLIP `nn.MultiheadAttention` guidance
- Regularization defaults

```console
$ PYTHONPATH=. pytest -q nvidia_tao_core/tests/scripts/test_generate_schema.py
305 passed

$ pre-commit run --files \
    nvidia_tao_core/config/clip/default_config.py \
    nvidia_tao_core/tests/scripts/test_generate_schema.py

TruffleHog secret scan...................................................Passed
license header...........................................................Passed
pylint...................................................................Passed
pydocstyle...............................................................Passed
flake8...................................................................Passed
```

The schema-cleaning path was also manually verified to preserve valid `peft` and `regularization` settings. The CLIP PEFT dataclass fields, defaults, valid options, and scalar metadata were compared directly with tao-pytorch commit `5601f556`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

```release-note
Added CLIP API schema support for per-tower LoRA, full, and frozen adaptation modes and preservation regularization.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All relevant tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] This change does not require a version, changelog, or migration update
- [x] This change does not add or modify optional-package imports
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

This is the `tao-core` schema companion to NVIDIA-TAO/tao-pytorch#106.

The primary review points are:

- `nvidia_tao_core/config/clip/default_config.py` for runtime/schema parity
- `test_clip_peft_and_regularization_schema` for generated-schema coverage
